### PR TITLE
fix(mcpb): restrict manifest compatibility to build platform

### DIFF
--- a/scripts/build-mcpb.cjs
+++ b/scripts/build-mcpb.cjs
@@ -279,6 +279,8 @@ async function main() {
     const binaryPath = PLATFORM === 'win32' ? 'bin/tomtom-mcp.cmd' : 'bin/tomtom-mcp';
     manifest.server.entry_point = binaryPath;
     manifest.server.mcp_config.command = '${__dirname}/' + binaryPath;
+    // Manifest only claims the platform it was built for; otherwise, it accepts another OS's bundle and fails
+    manifest.compatibility.platforms = [PLATFORM];
     fs.writeFileSync(path.join(TEMP_DIR, 'manifest.json'), JSON.stringify(manifest, null, 2));
     console.log('  ✓ Manifest');
 


### PR DESCRIPTION
## What

Each `.mcpb` bundle ships a single Node runtime for the platform it was built on, but the manifest inside every bundle claimed compatibility with darwin, win32 and linux. Claude Desktop therefore accepted any bundle on any OS. When the wrong one was installed (for example the darwin bundle on Windows, see #220), the server failed silently on stdio init because the bundled Node binary cannot execute on that OS.

The build script already detects the platform it is building for. This PR makes the manifest honest about it: compatibility is narrowed to exactly that platform, so a wrong-platform install is now rejected at install time with a clear error instead of failing silently at launch.

## Mental model

One bundle, one platform, one claim. The manifest template lists every platform we support; each built bundle keeps only the platform its binary actually runs on.
```
manifest-binary.json (all platforms) → build-mcpb.cjs detects process.platform → narrows compatibility.platforms to [build platform] → tomtom-maps-mcp-{platform}-{arch}.mcpb → Claude Desktop validates platform at install
```

## Change

* `scripts/build-mcpb.cjs`: after copying the manifest, set `compatibility.platforms = [PLATFORM]`. The template `manifest-binary.json` stays untouched as the source of truth for the full supported set.

## Verification

* Downloaded the released v1.6.7 win32 asset and confirmed the build pipeline itself is correct (`node.exe`, PE header, `.cmd` launcher). The bug is purely the manifest claim.
* Simulated the manifest mutation locally on darwin: produces `{"platforms":["darwin"]}`.

## Next steps

* Test the bundles on Mac and Windows to confirm install and launch work correctly.
* Cut a new release so users pick up the corrected manifests.