### PR TITLE
fix(tools): rewrite tool descriptions in descriptive voice

### DIFF
--- a/src/tools/dataVizOrbisTools.ts
+++ b/src/tools/dataVizOrbisTools.ts
@@ -40,12 +40,12 @@ export async function createDataVizOrbisTools(server: McpServer): Promise<void> 
       title: "TomTom Data Visualization",
       description:
         "Visualize custom GeoJSON data on an interactive TomTom basemap. " +
-        "Use this for LARGE DATASETS, heatmaps, cluster maps, choropleth maps, or when you have GeoJSON data (from a URL or inline) to render on a map. " +
+        "Intended for large datasets, heatmaps, cluster maps, choropleth maps, or GeoJSON data (from a URL or inline) rendered on a map. " +
         "Supports markers, heatmaps, clusters, lines, polygon fills, and choropleth maps. " +
         "Provide data via HTTPS URL or inline GeoJSON. Multiple layers can be overlaid in a single call. " +
         "Point features are automatically enriched with TomTom address data when clicked (reverse geocode). " +
-        "For placing a few specific markers, routes, or polygons, use tomtom-dynamic-map instead. " +
-        "For route calculations (directions, travel time), use tomtom-routing.",
+        "Placing a few specific markers, routes, or polygons is handled by tomtom-dynamic-map; " +
+        "route calculations (directions, travel time) are handled by tomtom-routing.",
       inputSchema: tomtomDataVizSchema,
       annotations: {
         title: "TomTom Data Visualization",

--- a/src/tools/mapOrbisTools.ts
+++ b/src/tools/mapOrbisTools.ts
@@ -41,9 +41,9 @@ export async function createMapOrbisTools(server: McpServer): Promise<void> {
       title: "TomTom Dynamic Map",
       description:
         "Render a custom map image with markers, drawn lines, polygons, and area overlays — with interactive map UI. " +
-        "Use this for MAP VISUALIZATION: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
-        "Do NOT use this for: route calculations (use tomtom-routing), traffic incidents (use tomtom-traffic), or large-dataset visualization like heatmaps/clusters/choropleth (use tomtom-data-viz). " +
-        "The optional routePlans parameter can calculate and draw routes on the map, but only use it when you need routes combined with other map elements (markers, polygons) in a single image.",
+        "Intended for map visualization: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
+        "Not intended for route calculations (tomtom-routing), traffic incidents (tomtom-traffic), or large-dataset visualization like heatmaps/clusters/choropleth (tomtom-data-viz). " +
+        "The optional routePlans parameter can calculate and draw routes on the map; it is meant for routes combined with other map elements (markers, polygons) in a single image.",
       inputSchema: schemas.tomtomDynamicMapSchema,
       annotations: {
         title: "TomTom Dynamic Map",

--- a/src/tools/mapTools.test.ts
+++ b/src/tools/mapTools.test.ts
@@ -50,7 +50,7 @@ describe("createMapTools", () => {
       "tomtom-dynamic-map",
       expect.objectContaining({
         title: "TomTom Dynamic Map",
-        description: expect.stringContaining("MAP VISUALIZATION"),
+        description: expect.stringContaining("map visualization"),
         inputSchema: expect.any(Object),
       }),
       expect.any(Function)

--- a/src/tools/mapTools.ts
+++ b/src/tools/mapTools.ts
@@ -51,9 +51,9 @@ export function createMapTools(server: McpServer): void {
       title: "TomTom Dynamic Map",
       description:
         "Render a custom map image with markers, drawn lines, polygons, and area overlays using server-side rendering. " +
-        "Use this for MAP VISUALIZATION: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
-        "Do NOT use this for: route calculations (use tomtom-routing), or traffic incidents (use tomtom-traffic). " +
-        "The optional routePlans parameter can calculate and draw routes on the map, but only use it when you need routes combined with other map elements (markers, polygons) in a single image.",
+        "Intended for map visualization: showing locations on a map, highlighting areas, or combining multiple visual elements in one view. " +
+        "Not intended for route calculations (tomtom-routing) or traffic incidents (tomtom-traffic). " +
+        "The optional routePlans parameter can calculate and draw routes on the map; it is meant for routes combined with other map elements (markers, polygons) in a single image.",
       inputSchema: schemas.tomtomDynamicMapSchema,
       annotations: {
         title: "TomTom Dynamic Map",

--- a/src/tools/routingOrbisTools.ts
+++ b/src/tools/routingOrbisTools.ts
@@ -50,7 +50,7 @@ export async function createRoutingOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Routing",
       description:
-        "Calculate optimal routes through an ordered list of locations [origin, ...stops, destination]. Use this tool FIRST when the user asks about directions, routes, travel time, or distance between places — whether it's a simple A-to-B or a multi-stop itinerary (e.g. 'route from Amsterdam to Berlin', 'drive from A to B via C and D'). Returns turn-by-turn directions, distance, travel time, and an interactive map. For visualizing multiple routes or combining routes with markers/polygons on a single map image, use tomtom-dynamic-map.",
+        "Calculate optimal routes through an ordered list of locations [origin, ...stops, destination]. The primary tool for directions, routes, travel time, or distance between places — whether a simple A-to-B or a multi-stop itinerary (e.g. 'route from Amsterdam to Berlin', 'drive from A to B via C and D'). Returns turn-by-turn directions, distance, travel time, and an interactive map. Visualizing multiple routes or combining routes with markers/polygons on a single map image is handled by tomtom-dynamic-map.",
       inputSchema: schemas.tomtomRoutingSchema,
       annotations: {
         title: "TomTom Routing",

--- a/src/tools/routingTools.ts
+++ b/src/tools/routingTools.ts
@@ -33,7 +33,7 @@ export function createRoutingTools(server: McpServer): void {
     {
       title: "TomTom Routing",
       description:
-        "Calculate optimal routes between two locations. Use this tool FIRST when the user asks about directions, routes, travel time, or distance between places (e.g. 'route from Amsterdam to Berlin', 'how long to drive from A to B'). Returns turn-by-turn directions, distance, travel time, and a map image. For multi-stop routes with 3+ waypoints, use tomtom-waypoint-routing instead. For visualizing multiple routes or combining routes with markers/polygons on a single map image, use tomtom-dynamic-map.",
+        "Calculate optimal routes between two locations. The primary tool for directions, routes, travel time, or distance between places (e.g. 'route from Amsterdam to Berlin', 'how long to drive from A to B'). Returns turn-by-turn directions, distance, travel time, and a map image. Multi-stop routes with 3+ waypoints are handled by tomtom-waypoint-routing; visualizing multiple routes or combining routes with markers/polygons on a single map image is handled by tomtom-dynamic-map.",
       inputSchema: schemas.tomtomRoutingSchema,
       annotations: {
         title: "TomTom Routing",

--- a/src/tools/searchOrbisTools.ts
+++ b/src/tools/searchOrbisTools.ts
@@ -141,7 +141,7 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom POI Search",
       description:
-        "Search for a specific business or POI by name, or browse an entire POI category. Best for finding a known place (e.g. 'Starbucks') or listing all businesses of a type (e.g. category 7315 for restaurants). Supports optional location bias but does NOT constrain results to a strict geographic boundary — use tomtom-area-search for that.",
+        "Search for a specific business or POI by name, or browse an entire POI category. Best for finding a known place (e.g. 'Starbucks') or listing all businesses of a type (e.g. the 'ITALIAN_RESTAURANT' category code from tomtom-poi-categories). Supports optional location bias but does not constrain results to a strict geographic boundary — tomtom-area-search does that.",
       inputSchema: schemas.tomtomPOISearchSchema,
       annotations: {
         title: "TomTom POI Search",
@@ -189,12 +189,12 @@ export async function createSearchOrbisTools(server: McpServer): Promise<void> {
     {
       title: "TomTom POI Categories",
       description:
-        "Look up POI category codes from natural language. REQUIRED before using poiCategories in any search tool. " +
-        "Category codes are UPPER_SNAKE_CASE text strings (e.g. 'ITALIAN_RESTAURANT', 'PARKING_GARAGE'), NOT numeric IDs. " +
-        "Workflow: (1) Extract the user's intent as keywords (e.g. user asks 'italian restaurants in Amsterdam' → filters: ['italian restaurant']). " +
-        "(2) Call this tool with those keywords in the filters parameter. " +
-        "(3) Use the returned text category codes in the poiCategories parameter of search tools (fuzzy-search, poi-search, nearby, area-search). " +
-        "Never guess or hardcode category codes — always discover them through this tool first.",
+        "Look up POI category codes from natural language. The poiCategories parameter of the search tools accepts only codes returned by this tool. " +
+        "Category codes are UPPER_SNAKE_CASE text strings (e.g. 'ITALIAN_RESTAURANT', 'PARKING_GARAGE'), not numeric IDs. " +
+        "Workflow: (1) extract the user's intent as keywords (e.g. 'italian restaurants in Amsterdam' → filters: ['italian restaurant']); " +
+        "(2) call this tool with those keywords in the filters parameter; " +
+        "(3) pass the returned category codes in the poiCategories parameter of search tools (fuzzy-search, poi-search, nearby, area-search). " +
+        "Guessed or hardcoded category codes are unreliable; this tool is the source of valid codes.",
       inputSchema: schemas.tomtomPOICategoriesSchema,
       annotations: {
         title: "TomTom POI Categories",

--- a/src/tools/trafficOrbisTools.ts
+++ b/src/tools/trafficOrbisTools.ts
@@ -38,9 +38,9 @@ export async function createTrafficOrbisTools(server: McpServer): Promise<void> 
     {
       title: "TomTom Traffic",
       description:
-        "Find and display traffic incidents in an area on an interactive map. Use this tool FIRST when the user asks about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
+        "Find and display traffic incidents in an area on an interactive map. The primary tool for questions about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
         "Incidents are rendered as styled icons on the map and can be clicked for details (severity, description, delay, road name). " +
-        "Do NOT use tomtom-dynamic-map to plot traffic incidents as markers — this tool already provides a complete interactive traffic visualization.",
+        "Already provides a complete interactive traffic visualization; plotting incidents as markers with tomtom-dynamic-map is not needed.",
       inputSchema: schemas.tomtomTrafficSchema,
       annotations: {
         title: "TomTom Traffic",

--- a/src/tools/trafficTools.ts
+++ b/src/tools/trafficTools.ts
@@ -28,9 +28,9 @@ export function createTrafficTools(server: McpServer): void {
     {
       title: "TomTom Traffic",
       description:
-        "Find and display traffic incidents in an area. Use this tool FIRST when the user asks about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
+        "Find and display traffic incidents in an area. The primary tool for questions about traffic, accidents, road closures, congestion, or dangerous road conditions. " +
         "Returns detailed incident data including severity, description, delay, and affected roads. " +
-        "Do NOT use tomtom-dynamic-map to plot traffic incidents as markers — this tool provides complete traffic incident data.",
+        "Provides complete traffic incident data on its own; plotting incidents as markers with tomtom-dynamic-map is not needed.",
       inputSchema: schemas.tomtomTrafficSchema,
       annotations: {
         title: "TomTom Traffic",


### PR DESCRIPTION
## What

Rewrites the MCP tool descriptions so they describe each tool instead of  instructing the model, and fixes one factually wrong example.

## Why

We are submitting the MCP server to the OpenAI Plugins Directory. OpenAI's review guidance treats tool metadata as a common rejection area:

* [Plugin guidelines](https://developers.openai.com/plugins/app-guidelines) state that descriptions must explain purpose "explicitly and accurately", must not encourage overly broad triggering, and that plugins cannot manipulate model selection.
* [Optimize Metadata](https://developers.openai.com/plugins/guides/optimize-metadata) and [Define tools](https://developers.openai.com/plugins/plan/tools) describe the expected style: state what the tool does, explain when to use it, distinguish it from similar tools.

The mental model: a description is a label on the tool, not a command to the model.

## Changes

* Removed selection priority language ("Use this tool FIRST") and workflow commands ("Never guess", "REQUIRED before") from 9 descriptions across 8 tool files. When-to-use guidance and cross-tool differentiation stay, since the same guidance recommends them.
* Fixed `tomtom-poi-search` citing "category 7315 for restaurants": category codes are UPPER_SNAKE_CASE text per `tomtom-poi-categories`, so the example now uses `'ITALIAN_RESTAURANT'`.
* Updated one test that pinned the old wording (`mapTools.test.ts`).

## Compatibility

No tool names, schemas, or behavior change, so the MCP contract is intact for the existing Anthropic directory listing. Anthropic serves tool metadata live and has no re-review process for description changes. Routing semantics are
preserved in descriptive voice to keep Claude's tool selection stable.