### PR TITLE
[POC] LSI-901 feat: stage 2 — compute on the server (9/14 answered, −60% tokens)

### DIFF
--- a/evals/compare-phases.ts
+++ b/evals/compare-phases.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Rolls a phase sweep up into one comparable table.
+ *
+ *   npx tsx evals/compare-phases.ts evals/capability/runs/phases-<sweep>
+ *
+ * Every phase is reported twice: against phase 0 (what the whole exercise
+ * bought) and against the phase before it (what THIS step bought). The second
+ * is the one that can be acted on — it is the only view in which a step that
+ * cost tokens and returned nothing is visible, because a cumulative total hides
+ * it behind the step before.
+ *
+ * Capability metrics are MEDIANS over the sweep's repeats, with the observed
+ * range beside them. A median with a range of 8–13 is not a measurement anyone
+ * should make a decision from, and printing the range is what makes that
+ * obvious rather than discoverable.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readScenarioLog, summarizeScenarios } from "./harness/scenario-log";
+import { PHASES } from "./phases";
+
+const ROOT_DIR = fileURLToPath(new URL("..", import.meta.url));
+const RUNS_DIR = path.resolve(process.argv[2] ?? "");
+if (!fs.existsSync(RUNS_DIR)) throw new Error(`No sweep directory at ${RUNS_DIR}`);
+
+interface TaskResult {
+  id: string;
+  capability?: string;
+  expected?: string;
+  answered?: boolean;
+  grounded?: boolean;
+  tokens?: number;
+  toolsCalled?: string[];
+}
+interface Report {
+  model?: string;
+  summary: Record<string, number>;
+  results: TaskResult[];
+}
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+const rangeOf = (values: readonly number[]): [number, number] => [
+  Math.min(...values),
+  Math.max(...values),
+];
+
+const reportsFor = (id: string): Report[] =>
+  fs
+    .readdirSync(RUNS_DIR)
+    .filter((name) => name.startsWith(`report.${id}.`) && name.endsWith(".json"))
+    .sort()
+    .map((name) => JSON.parse(fs.readFileSync(path.join(RUNS_DIR, name), "utf-8")) as Report);
+
+/** Capability metrics carried across every phase, in report order. */
+const METRICS = [
+  "answered",
+  "grounded",
+  "blockedButAnswered",
+  "honestRefusals",
+  "judgedOnCompleteData",
+  "totalTokens",
+] as const;
+
+interface PhaseScore {
+  id: string;
+  ordinal: number;
+  title: string;
+  adds: string;
+  intent: string;
+  runs: number;
+  model?: string;
+  tasks: number;
+  capability: Record<string, { median: number; range: [number, number]; values: number[] }>;
+  /** Per task: how many of this phase's runs answered it. */
+  perTask: Record<string, { answered: number; grounded: number; of: number; expected?: string }>;
+  scenarios?: ReturnType<typeof summarizeScenarios>;
+}
+
+const score = (phase: (typeof PHASES)[number]): PhaseScore | undefined => {
+  const reports = reportsFor(phase.id);
+  if (reports.length === 0) return undefined;
+
+  const capability: PhaseScore["capability"] = {};
+  for (const metric of METRICS) {
+    const values = reports.map((r) => r.summary[metric] ?? 0);
+    capability[metric] = { median: median(values), range: rangeOf(values), values };
+  }
+
+  const perTask: PhaseScore["perTask"] = {};
+  for (const report of reports) {
+    for (const result of report.results) {
+      const entry = (perTask[result.id] ??= {
+        answered: 0,
+        grounded: 0,
+        of: 0,
+        expected: result.expected,
+      });
+      entry.of += 1;
+      if (result.answered) entry.answered += 1;
+      if (result.grounded) entry.grounded += 1;
+    }
+  }
+
+  const scenarioLog = path.join(RUNS_DIR, `runs.${phase.id}.jsonl`);
+  const scenarios = fs.existsSync(scenarioLog)
+    ? summarizeScenarios(readScenarioLog(scenarioLog))
+    : undefined;
+
+  return {
+    id: phase.id,
+    ordinal: phase.ordinal,
+    title: phase.title,
+    adds: phase.adds,
+    intent: phase.intent,
+    runs: reports.length,
+    model: reports[0]?.model,
+    tasks: reports[0]?.results.length ?? 0,
+    capability,
+    perTask,
+    scenarios,
+  };
+};
+
+const scored = PHASES.map(score).filter((s): s is PhaseScore => s !== undefined);
+if (scored.length === 0) throw new Error(`No phase reports found in ${RUNS_DIR}`);
+
+const signed = (n: number): string => (n > 0 ? `+${n}` : `${n}`);
+const fmt = (n: number): string => (Number.isInteger(n) ? `${n}` : n.toFixed(1));
+const rangeText = (r: [number, number]): string => (r[0] === r[1] ? `${r[0]}` : `${r[0]}–${r[1]}`);
+
+const lines: string[] = [];
+lines.push("# Phase comparison");
+lines.push("");
+lines.push(
+  `Model: ${scored[0].model ?? "unknown"} · wiring: stdio · ` +
+    `${scored[0].runs} capability run(s) per phase · generated ${new Date().toISOString()}`
+);
+lines.push("");
+lines.push(
+  "Runs were interleaved (phase 0, 1, 2, 3 · phase 0, 1, 2, 3 · …) so drift in the live",
+  "APIs cannot land on one phase and read as a result. Capability figures are medians;",
+  "the range beside each is the spread across repeats, and a wide one means the metric",
+  "cannot separate these phases at this sample size."
+);
+lines.push("");
+
+lines.push("## What each phase adds");
+lines.push("");
+lines.push("| Phase | Adds | Tools |");
+lines.push("| --- | --- | --- |");
+for (const s of scored) {
+  const tools = s.scenarios ? "" : "";
+  lines.push(`| **${s.ordinal}. ${s.title}** | ${s.adds} | ${tools} |`);
+}
+lines.push("");
+
+lines.push("## Capability — medians");
+lines.push("");
+const header = ["Metric", ...scored.map((s) => `${s.id} (median)`)];
+lines.push(`| ${header.join(" | ")} |`);
+lines.push(`| --- |${scored.map(() => " ---: |").join("")}`);
+for (const metric of METRICS) {
+  const cells = scored.map((s) => {
+    const m = s.capability[metric];
+    return `${fmt(m.median)} <sub>${rangeText(m.range)}</sub>`;
+  });
+  lines.push(`| ${metric} | ${cells.join(" | ")} |`);
+}
+lines.push("");
+
+lines.push("## Each phase against phase 0, and against the phase before it");
+lines.push("");
+lines.push(
+  "| Metric | " +
+    scored
+      .slice(1)
+      .map((s) => `${s.id} vs 0 | ${s.id} vs ${s.ordinal - 1}`)
+      .join(" | ") +
+    " |"
+);
+lines.push(
+  "| --- |" +
+    scored
+      .slice(1)
+      .map(() => " ---: | ---: |")
+      .join("")
+);
+for (const metric of METRICS) {
+  const cells: string[] = [];
+  for (const s of scored.slice(1)) {
+    const base = scored[0].capability[metric].median;
+    const prev = scored.find((p) => p.ordinal === s.ordinal - 1)?.capability[metric].median ?? base;
+    cells.push(signed(s.capability[metric].median - base));
+    cells.push(signed(s.capability[metric].median - prev));
+  }
+  lines.push(`| ${metric} | ${cells.join(" | ")} |`);
+}
+lines.push("");
+
+lines.push("## Per task — runs that answered it");
+lines.push("");
+lines.push(
+  "A task answered in every run is a capability. One answered in half of them is a coin",
+  "flip, and no single run can tell the two apart."
+);
+lines.push("");
+const taskIds = Object.keys(scored[0].perTask);
+lines.push(`| Task | expected | ${scored.map((s) => s.id).join(" | ")} |`);
+lines.push(`| --- | --- |${scored.map(() => " :---: |").join("")}`);
+for (const id of taskIds) {
+  const cells = scored.map((s) => {
+    const t = s.perTask[id];
+    return t ? `${t.answered}/${t.of}` : "—";
+  });
+  lines.push(`| ${id} | ${scored[0].perTask[id]?.expected ?? ""} | ${cells.join(" | ")} |`);
+}
+lines.push("");
+
+if (scored.some((s) => s.scenarios)) {
+  lines.push("## Tool selection");
+  lines.push("");
+  lines.push(
+    "A scenario the target surface cannot express is excluded from the denominator rather",
+    "than counted as a failure — scoring a phase for not calling a tool it does not carry",
+    "would manufacture an improvement out of a tautology."
+  );
+  lines.push("");
+  const rows = [
+    ["evaluated", (s: PhaseScore) => s.scenarios?.evaluated],
+    ["not expressible", (s: PhaseScore) => s.scenarios?.skippedUnrepresentable],
+    ["routed correctly", (s: PhaseScore) => s.scenarios?.passed],
+    [
+      "accuracy",
+      (s: PhaseScore) => (s.scenarios ? `${(s.scenarios.accuracy * 100).toFixed(1)}%` : undefined),
+    ],
+    ["mean hops", (s: PhaseScore) => s.scenarios?.meanHops.toFixed(2)],
+    ["median hops", (s: PhaseScore) => s.scenarios?.medianHops],
+    ["total tokens", (s: PhaseScore) => s.scenarios?.totalTokens.toLocaleString()],
+  ] as const;
+  lines.push(`| Metric | ${scored.map((s) => s.id).join(" | ")} |`);
+  lines.push(`| --- |${scored.map(() => " ---: |").join("")}`);
+  for (const [name, get] of rows) {
+    lines.push(`| ${name} | ${scored.map((s) => get(s) ?? "—").join(" | ")} |`);
+  }
+  lines.push("");
+}
+
+const markdown = `${lines.join("\n")}\n`;
+fs.writeFileSync(path.join(ROOT_DIR, "evals/phase-comparison.md"), markdown);
+fs.writeFileSync(
+  path.join(ROOT_DIR, "evals/phase-results.json"),
+  `${JSON.stringify({ sweep: path.basename(RUNS_DIR), generatedAt: new Date().toISOString(), phases: scored }, null, 2)}\n`
+);
+console.log(markdown);
+console.log("wrote evals/phase-comparison.md and evals/phase-results.json");

--- a/evals/harness/comparison.test.ts
+++ b/evals/harness/comparison.test.ts
@@ -75,7 +75,12 @@ describe("resolveTarget", () => {
 });
 
 describe("assertTransportForTarget", () => {
-  const baseline = { root: "/elsewhere", label: "baseline", isBaseline: true };
+  const baseline = {
+    root: "/elsewhere",
+    label: "baseline",
+    isBaseline: true,
+    surface: "legacy" as const,
+  };
 
   it("refuses an in-process baseline run", () => {
     // The failure this prevents is the quiet one: in-process tools come from
@@ -343,5 +348,25 @@ describe("scenarioModelMismatch", () => {
     // mismatch on every comparison that skipped a dataset tool.
     const baseline = [record("gpt-5.1"), record("", { unrepresentable: ["tomtom-analyse-data"] })];
     expect(scenarioModelMismatch(baseline, [record("gpt-5.1")])).toBeUndefined();
+  });
+});
+
+/*
+ * A phase series has more than two surfaces, so "which checkout" stopped being
+ * a usable proxy for "which tool vocabulary".
+ */
+describe("resolveTarget surface", () => {
+  it("still infers legacy for a baseline and consolidated for this tree", () => {
+    expect(resolveTarget({}).surface).toBe("consolidated");
+    expect(resolveTarget({ EVAL_SERVER_ROOT: REPO_ROOT }).surface).toBe("consolidated");
+  });
+
+  it("takes EVAL_SURFACE over the inference, so a phase worktree is not read as legacy", () => {
+    const target = resolveTarget({ EVAL_SERVER_ROOT: REPO_ROOT, EVAL_SURFACE: "legacy" });
+    expect(target.surface).toBe("legacy");
+  });
+
+  it("rejects a surface it does not know rather than guessing one", () => {
+    expect(() => resolveTarget({ EVAL_SURFACE: "newer" })).toThrow(/not one of/);
   });
 });

--- a/evals/harness/scenario.ts
+++ b/evals/harness/scenario.ts
@@ -294,18 +294,18 @@ const firstArgProblem = (
 /**
  * The expectation as it will actually be evaluated.
  *
- * On this working tree that is the expectation as written. Against a baseline
- * (`EVAL_SERVER_ROOT`) it is rewritten onto the tool names that server really
- * advertises, so a scenario asserting `tomtom-discover-places` is scored on
- * whether the old agent reached for any of the seven tools that became it —
- * the question worth asking — rather than on a name that did not exist yet.
+ * On a consolidated surface that is the expectation as written. On the `legacy`
+ * surface it is rewritten onto the tool names that server really advertises, so
+ * a scenario asserting `tomtom-discover-places` is scored on whether the old
+ * agent reached for any of the seven tools that became it — the question worth
+ * asking — rather than on a name that did not exist yet.
  */
 const resolveExpectation = (options: {
   expectedTool: string;
   acceptedAlternatives: readonly string[];
   forbiddenTools: readonly string[];
 }): { accepted: string[]; banned: string[]; legacy?: TranslatedExpectation } => {
-  if (!TARGET.isBaseline) {
+  if (TARGET.surface === "consolidated") {
     return {
       accepted: [options.expectedTool, ...options.acceptedAlternatives],
       banned: [...options.forbiddenTools],
@@ -328,9 +328,7 @@ const skipUnrepresentable = (
   expectedTool: string,
   unrepresentable: string[]
 ): ScenarioOutcome => {
-  const reason =
-    `[${TARGET.label}] not evaluated: ${unrepresentable.join(", ")} had no equivalent ` +
-    "on this tool surface";
+  const reason = `[${TARGET.label}] not evaluated: ${unrepresentable.join(", ")} not on this tool surface`;
   console.warn(`  ⊘ ${reason} — "${prompt}"`);
   recordScenario({
     label: TARGET.label,
@@ -370,8 +368,25 @@ export const createToolScenarioRunner =
       forbiddenTools,
     });
 
-    if (legacy?.unrepresentable.length && accepted.length === 0) {
-      return skipUnrepresentable(prompt, expectedTool, legacy.unrepresentable);
+    const session = mode === "stdio" ? await getSharedSession() : undefined;
+
+    // A scenario only means something if the target advertises a tool that could
+    // satisfy it. The legacy map answers that for the pre-consolidation surface;
+    // for everything else the SERVER answers it, by way of what it listed.
+    //
+    // This matters for a phase series rather than a two-way A/B: phases 1 and 2
+    // speak the consolidated vocabulary but carry no dataset tools, so a
+    // registry-derived scenario expecting `tomtom-analyse-data` would be scored
+    // as a routing failure on a surface where the tool does not exist — the same
+    // tautology the legacy path already refuses to count.
+    const advertised = session?.toolNames;
+    const reachable = advertised ? accepted.filter((name) => advertised.includes(name)) : accepted;
+
+    if (reachable.length === 0) {
+      const missing = legacy?.unrepresentable.length
+        ? legacy.unrepresentable
+        : [expectedTool, ...acceptedAlternatives];
+      return skipUnrepresentable(prompt, expectedTool, missing);
     }
 
     // `inOrder` and `expectedArgs` are written against the current schemas — a
@@ -380,8 +395,6 @@ export const createToolScenarioRunner =
     // remains (which tool, how many hops) honest rather than uniformly failing.
     const orderedTools = legacy ? undefined : inOrder;
     const argChecks = legacy ? undefined : expectedArgs;
-
-    const session = mode === "stdio" ? await getSharedSession() : undefined;
     // Staged once, not per model: a live seed issues a real tool call, and each
     // model must see the same history for their results to be comparable.
     const staged = (await priorTurns?.()) ?? [];
@@ -403,7 +416,7 @@ export const createToolScenarioRunner =
 
       const problem = answeredFromContext
         ? undefined
-        : (expectAnyToolCalled(run, ...accepted) ??
+        : (expectAnyToolCalled(run, ...reachable) ??
           (orderedTools?.length ? expectToolCalledInOrder(run, ...orderedTools) : undefined) ??
           (banned.length ? expectNoneOfToolsCalled(run, ...banned) : undefined) ??
           (argChecks ? firstArgProblem(run, argChecks) : undefined));
@@ -415,7 +428,7 @@ export const createToolScenarioRunner =
         serverRoot: TARGET.root,
         prompt,
         expectedTool,
-        accepted,
+        accepted: reachable,
         forbidden: banned,
         droppedForbidden: legacy?.droppedForbidden,
         modelId: id,

--- a/evals/harness/seed.ts
+++ b/evals/harness/seed.ts
@@ -130,4 +130,4 @@ export const liveSeed = (
 
 /** True when seeds will be executed for real — useful in diagnostics. */
 export const seedsAreLive = (): boolean =>
-  process.env.EVAL_TRANSPORT === "stdio" && !TARGET.isBaseline;
+  process.env.EVAL_TRANSPORT === "stdio" && TARGET.surface === "consolidated";

--- a/evals/harness/target.ts
+++ b/evals/harness/target.ts
@@ -35,6 +35,22 @@ import { basename, isAbsolute, join, resolve } from "node:path";
 /** This checkout. `harness/` → `evals/` → repo root. */
 export const REPO_ROOT = resolve(join(import.meta.dirname, "..", ".."));
 
+/**
+ * Which tool vocabulary the target advertises.
+ *
+ * `legacy` is the pre-consolidation surface (15 tools: `tomtom-geocode`,
+ * `tomtom-fuzzy-search`, …). `consolidated` is every surface from the tool
+ * collapse onwards, whose names the scenarios are written against.
+ *
+ * This used to be inferred from `isBaseline` — "not this working tree" — which
+ * held only while there were exactly two surfaces. Comparing a PHASE SERIES
+ * breaks that inference: phases 1, 2 and 3 all live in their own worktrees and
+ * all speak the consolidated vocabulary, so inferring `legacy` from "somewhere
+ * else" would translate their expectations onto tool names they never advertise
+ * and score them zero.
+ */
+export type EvalSurface = "legacy" | "consolidated";
+
 export interface EvalTarget {
   /** Checkout whose `bin/tomtom-mcp.js` is spawned. */
   root: string;
@@ -42,7 +58,25 @@ export interface EvalTarget {
   label: string;
   /** True when the server under test is NOT this working tree. */
   isBaseline: boolean;
+  /** The tool vocabulary this target speaks. */
+  surface: EvalSurface;
 }
+
+/**
+ * Resolves the target's surface.
+ *
+ * `EVAL_SURFACE` is explicit and always wins. Without it the old inference is
+ * kept exactly — a baseline is `legacy`, this tree is `consolidated` — so an
+ * existing two-way A/B needs no edits.
+ */
+const resolveSurface = (env: NodeJS.ProcessEnv, isBaseline: boolean): EvalSurface => {
+  const requested = env.EVAL_SURFACE?.trim();
+  if (!requested) return isBaseline ? "legacy" : "consolidated";
+  if (requested !== "legacy" && requested !== "consolidated") {
+    throw new Error(`EVAL_SURFACE="${requested}" is not one of: legacy, consolidated.`);
+  }
+  return requested;
+};
 
 /**
  * Resolves the target from the environment.
@@ -60,7 +94,12 @@ export interface EvalTarget {
 export const resolveTarget = (env: NodeJS.ProcessEnv = process.env): EvalTarget => {
   const requested = env.EVAL_SERVER_ROOT?.trim();
   if (!requested) {
-    return { root: REPO_ROOT, label: env.EVAL_LABEL?.trim() ?? "", isBaseline: false };
+    return {
+      root: REPO_ROOT,
+      label: env.EVAL_LABEL?.trim() ?? "",
+      isBaseline: false,
+      surface: resolveSurface(env, false),
+    };
   }
 
   const root = isAbsolute(requested) ? resolve(requested) : resolve(REPO_ROOT, requested);
@@ -76,6 +115,7 @@ export const resolveTarget = (env: NodeJS.ProcessEnv = process.env): EvalTarget 
     root,
     label: env.EVAL_LABEL?.trim() || (isBaseline ? basename(root) : ""),
     isBaseline,
+    surface: resolveSurface(env, isBaseline),
   };
 };
 

--- a/evals/phases.ts
+++ b/evals/phases.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The phase series under measurement.
+ *
+ * The consolidation landed as one commit, which makes "did it work" an
+ * unanswerable question: the tool collapse, server-side code execution and
+ * server-held datasets all arrived together, so any number moved by all three at
+ * once. These four checkouts take them apart, each adding exactly one thing to
+ * the one before it:
+ *
+ *   phase 0 → phase 1   fewer, wider tools               (no new capability)
+ *   phase 1 → phase 2   code execution over one result   (no state)
+ *   phase 2 → phase 3   datasets: handles, and code across them
+ *
+ * Every phase is scored by the SAME corpus, judge and model, run from THIS tree
+ * and pointed at each checkout in turn (`EVAL_SERVER_ROOT`). Nothing about the
+ * measurement changes between phases — only which server answers.
+ */
+
+export interface Phase {
+  /** Artefact label: `report.<id>.json`, `runs.<id>.jsonl`. */
+  id: string;
+  /** Ordinal, for "compared with the phase before it". */
+  ordinal: number;
+  /** Short name for reports. */
+  title: string;
+  /** Checkout, relative to the repo root. */
+  root: string;
+  /** Tool vocabulary — drives how scenario expectations are scored. */
+  surface: "legacy" | "consolidated";
+  /** What this phase adds to the one before it. */
+  adds: string;
+  /** One-paragraph statement of what it is for. */
+  intent: string;
+}
+
+export const PHASES: readonly Phase[] = [
+  {
+    id: "phase0",
+    ordinal: 0,
+    title: "Before the consolidation",
+    root: "../tomtom-mcp-baseline",
+    surface: "legacy",
+    adds: "—",
+    intent:
+      "The surface as it shipped: 15 model-visible tools, one per API endpoint. Every response " +
+      "is trimmed to fit the conversation and the trimming is lossy, so a question about a field " +
+      "that was dropped, or a total over a list that was capped, has no path to an answer.",
+  },
+  {
+    id: "phase1",
+    ordinal: 1,
+    title: "Consolidated tools",
+    root: "../tomtom-mcp-phase1",
+    surface: "consolidated",
+    adds: "Fewer, wider tools — no new capability",
+    intent:
+      "The tool collapse on its own: 15 tools become 9, with resolvers that take a place NAME " +
+      "where the old surface took coordinates. This is a HOP-COUNT change, not a capability " +
+      "change — nothing is answerable here that was not answerable before. Measuring it alone is " +
+      "what separates 'the agent picks the right tool' from 'the agent can compute the answer'.",
+  },
+  {
+    id: "phase2",
+    ordinal: 2,
+    title: "Code execution, no state",
+    root: "../tomtom-mcp-phase2",
+    surface: "consolidated",
+    adds: "`analyse` — code over this call's own result",
+    intent:
+      "Every data tool gains an optional `analyse`: JavaScript run on the server over the FULL " +
+      "untrimmed result of that same call, returning only what the code returns. The tool LIST is " +
+      "identical to phase 1, so any movement is attributable to code execution rather than to a " +
+      "new routing target. Nothing is held between calls, so the code sees one result at a time.",
+  },
+  {
+    id: "phase3",
+    ordinal: 3,
+    title: "Server-held datasets",
+    root: "../tomtom-mcp-phase3",
+    surface: "consolidated",
+    adds: "`dataset_id` handles + `describe-dataset` / `analyse-data`",
+    intent:
+      "Results become addressable. Every tool returns a `dataset_id`; `tomtom-describe-dataset` " +
+      "reports what is in one and `tomtom-analyse-data` runs code across SEVERAL. This is what " +
+      "phase 2 cannot express: relating one tool's result to another's, and refining an analysis " +
+      "without paying for the data twice.",
+  },
+];
+
+export const phaseById = (id: string): Phase | undefined => PHASES.find((p) => p.id === id);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "evals:compare": "tsx evals/compare.ts",
     "evals:ab": "tsx scripts/run-eval-ab.ts",
     "evals:medians": "tsx scripts/run-eval-medians.ts",
+    "evals:phases": "tsx scripts/run-phase-sweep.ts",
+    "evals:phases:compare": "tsx evals/compare-phases.ts",
     "type-check": "tsc --noEmit",
     "type-check:evals": "tsc --noEmit -p evals/tsconfig.json",
     "lint": "biome lint src evals",

--- a/scripts/run-phase-sweep.ts
+++ b/scripts/run-phase-sweep.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Scores every phase in `evals/phases.ts` with one corpus, one judge, one model.
+ *
+ *   pnpm evals:phases                 # 3 capability repeats + 1 scenario run each
+ *   EVAL_REPEAT=1 pnpm evals:phases   # a cheaper smoke of the same pipeline
+ *   EVAL_PHASES=phase1,phase2 pnpm evals:phases
+ *
+ * Runs are INTERLEAVED by repeat (0,1,2,3 · 0,1,2,3 · …) rather than grouped by
+ * phase. The corpus hits live traffic and search APIs, whose contents change
+ * through the day; running one phase to completion before starting the next
+ * would let that drift land entirely on one phase and read as a result.
+ *
+ * Capability is repeated because it is noisy — the same code has scored 8 and 13
+ * answered on different runs — so a single run cannot tell a real gain from a
+ * coin flip. Tool SELECTION is not repeated by default: it varies far less, and
+ * phases 1 and 2 advertise byte-identical tool lists, so a second run mostly buys
+ * a second copy of the same answer.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PHASES } from "../evals/phases";
+
+const ROOT_DIR = fileURLToPath(new URL("..", import.meta.url));
+const CAPABILITY_DIR = path.resolve(ROOT_DIR, "evals/capability");
+const SCENARIO_DIR = path.resolve(ROOT_DIR, "evals/scenarios");
+
+/** One directory per sweep, so a later sweep never overwrites this one's evidence. */
+const SWEEP_ID = new Date().toISOString().replace(/[:.]/g, "-");
+const RUNS_DIR = path.join(CAPABILITY_DIR, "runs", `phases-${SWEEP_ID}`);
+
+const REPEAT = Number(process.env.EVAL_REPEAT ?? 3);
+const WANTED = (process.env.EVAL_PHASES ?? PHASES.map((p) => p.id).join(","))
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+const SELECTED = PHASES.filter((phase) => WANTED.includes(phase.id));
+const WITH_SCENARIOS = process.env.EVAL_SKIP_SCENARIOS !== "1";
+
+if (SELECTED.length === 0) throw new Error(`No phases matched EVAL_PHASES="${WANTED.join(",")}".`);
+
+const reportPath = (id: string) => path.join(CAPABILITY_DIR, `report.${id}.json`);
+const scenarioPath = (id: string) => path.join(SCENARIO_DIR, `runs.${id}.jsonl`);
+const stampOf = (file: string): number | null =>
+  fs.existsSync(file) ? fs.statSync(file).mtimeMs : null;
+
+/** Environment a phase is measured under. Only the target changes between them. */
+const envFor = (phase: (typeof PHASES)[number]) => ({
+  ...process.env,
+  EVAL_TRANSPORT: "stdio",
+  EVAL_SERVER_ROOT: phase.root,
+  EVAL_LABEL: phase.id,
+  EVAL_SURFACE: phase.surface,
+});
+
+/** How many tasks a just-written report failed to score. */
+const notMeasuredIn = (id: string): number => {
+  try {
+    return JSON.parse(fs.readFileSync(reportPath(id), "utf-8")).summary?.notMeasured ?? 0;
+  } catch {
+    return 0;
+  }
+};
+
+interface Attempt {
+  ok: boolean;
+  status: number | null;
+}
+
+/**
+ * Runs one suite against one phase, insisting it rewrote its artefact.
+ *
+ * A non-zero exit is normal — the corpus contains tasks a phase is expected to
+ * fail. An artefact that did NOT change is not: it means the suite died before
+ * recording anything, and the stale file on disk would otherwise be read as this
+ * run's result.
+ */
+const runSuite = (
+  phase: (typeof PHASES)[number],
+  suite: "capability" | "scenarios",
+  artefact: string,
+  attempts = 2
+): Attempt => {
+  let before = stampOf(artefact);
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const { status } = spawnSync(
+      "npx",
+      ["vitest", "run", "--config", "evals/vitest.config.ts", `evals/${suite}`],
+      { cwd: ROOT_DIR, stdio: "inherit", env: envFor(phase) }
+    );
+    const after = stampOf(artefact);
+    if (after !== null && after !== before) {
+      const missing = suite === "capability" ? notMeasuredIn(phase.id) : 0;
+      if (missing === 0) return { ok: true, status };
+      console.log(`\n  ${phase.id} scored ${missing} task(s) short — repeating it.`);
+      before = after;
+      continue;
+    }
+    console.log(`\n  ${phase.id} ${suite} recorded nothing (exit ${status}) — retrying.`);
+  }
+  return { ok: false, status: null };
+};
+
+fs.mkdirSync(RUNS_DIR, { recursive: true });
+console.log(
+  `sweep ${SWEEP_ID}\nphases: ${SELECTED.map((p) => p.id).join(", ")}\n` +
+    `capability repeats: ${REPEAT}   scenarios: ${WITH_SCENARIOS ? "once each" : "skipped"}\n`
+);
+
+for (let run = 1; run <= REPEAT; run += 1) {
+  for (const phase of SELECTED) {
+    console.log(`\n─── capability  run ${run}/${REPEAT}  ${phase.id} (${phase.title})\n`);
+    const attempt = runSuite(phase, "capability", reportPath(phase.id));
+    if (!attempt.ok) {
+      console.error(
+        `\n✗ ${phase.id} run ${run} recorded nothing. Stopping rather than taking a median ` +
+          "over a run that did not happen.\n"
+      );
+      process.exit(1);
+    }
+    fs.copyFileSync(reportPath(phase.id), path.join(RUNS_DIR, `report.${phase.id}.${run}.json`));
+  }
+}
+
+if (WITH_SCENARIOS) {
+  for (const phase of SELECTED) {
+    console.log(`\n─── scenarios  ${phase.id} (${phase.title})\n`);
+    const attempt = runSuite(phase, "scenarios", scenarioPath(phase.id));
+    if (!attempt.ok) {
+      console.error(`\n✗ ${phase.id} scenarios recorded nothing.\n`);
+      process.exit(1);
+    }
+    fs.copyFileSync(scenarioPath(phase.id), path.join(RUNS_DIR, `runs.${phase.id}.jsonl`));
+  }
+}
+
+console.log(`\nsweep complete — evidence in ${path.relative(ROOT_DIR, RUNS_DIR)}\n`);
+const rollup = spawnSync("npx", ["tsx", "evals/compare-phases.ts", RUNS_DIR], {
+  cwd: ROOT_DIR,
+  stdio: "inherit",
+});
+process.exit(rollup.status ?? 0);

--- a/src/schemas/routing/planRouteSchema.ts
+++ b/src/schemas/routing/planRouteSchema.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { locationInputSchema } from "../../tools/shared/inputs/location-input";
 import { whereSchema } from "../../tools/shared/inputs/resolve-where";
 import { uiVisibilityParam } from "../search/common";
+import { analyseSchema } from "../shared/analyseSchema";
 import { routingOptionsSchema } from "./common";
 
 /**
@@ -63,6 +64,8 @@ const evSchema = z
   );
 
 export const tomtomPlanRouteSchema = {
+  analyse: analyseSchema,
+
   locations: z
     .array(locationInputSchema)
     .min(2)
@@ -91,6 +94,8 @@ const budgetSchema = z
   .describe("One budget constraint.");
 
 export const tomtomFindReachableAreasSchema = {
+  analyse: analyseSchema,
+
   origins: z
     .array(locationInputSchema)
     .min(1)
@@ -112,6 +117,8 @@ export const tomtomFindReachableAreasSchema = {
 export type FindReachableAreasParams = z.input<z.ZodObject<typeof tomtomFindReachableAreasSchema>>;
 
 export const tomtomGetTrafficSchema = {
+  analyse: analyseSchema,
+
   where: whereSchema.describe(
     "The area to report traffic for. Use mode `within` and name the area in `queries` " +
       '(e.g. ["Amsterdam"]) — no separate geocode step. `boundingBox` works if you have exact ' +
@@ -136,7 +143,7 @@ export const tomtomGetTrafficSchema = {
     .optional()
     .describe(
       "Maximum incidents shown (default 100). The FULL set is held server-side regardless — use " +
-        "narrow the area rather than counting or grouping over the visible rows."
+        "pass `analyse` to count or group over every incident rather than the visible rows."
     ),
   language: z.string().optional().describe("IETF language tag for descriptions, e.g. 'nl-NL'."),
   ...uiVisibilityParam,

--- a/src/schemas/routing/planRouteSchema.ts
+++ b/src/schemas/routing/planRouteSchema.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 import { locationInputSchema } from "../../tools/shared/inputs/location-input";
 import { whereSchema } from "../../tools/shared/inputs/resolve-where";
 import { uiVisibilityParam } from "../search/common";
-import { analyseSchema } from "../shared/analyseSchema";
+import { analyseSchemaFor } from "../shared/analyseSchema";
 import { routingOptionsSchema } from "./common";
 
 /**
@@ -64,7 +64,7 @@ const evSchema = z
   );
 
 export const tomtomPlanRouteSchema = {
-  analyse: analyseSchema,
+  analyse: analyseSchemaFor("tomtom-plan-route"),
 
   locations: z
     .array(locationInputSchema)
@@ -94,7 +94,7 @@ const budgetSchema = z
   .describe("One budget constraint.");
 
 export const tomtomFindReachableAreasSchema = {
-  analyse: analyseSchema,
+  analyse: analyseSchemaFor("tomtom-find-reachable-areas"),
 
   origins: z
     .array(locationInputSchema)
@@ -117,7 +117,7 @@ export const tomtomFindReachableAreasSchema = {
 export type FindReachableAreasParams = z.input<z.ZodObject<typeof tomtomFindReachableAreasSchema>>;
 
 export const tomtomGetTrafficSchema = {
-  analyse: analyseSchema,
+  analyse: analyseSchemaFor("tomtom-get-traffic"),
 
   where: whereSchema.describe(
     "The area to report traffic for. Use mode `within` and name the area in `queries` " +

--- a/src/schemas/search/discoverPlacesSchema.ts
+++ b/src/schemas/search/discoverPlacesSchema.ts
@@ -18,11 +18,11 @@ import { z } from "zod";
 import { queryAsSchema } from "../../tools/shared/inputs/location-input";
 import { POI_CATEGORIES_DOC } from "../../tools/shared/inputs/resolve-poi-categories";
 import { whereSchema } from "../../tools/shared/inputs/resolve-where";
-import { analyseSchema } from "../shared/analyseSchema";
+import { analyseSchemaFor } from "../shared/analyseSchema";
 import { uiVisibilityParam } from "./common";
 
 export const tomtomDiscoverPlacesSchema = {
-  analyse: analyseSchema,
+  analyse: analyseSchemaFor("tomtom-discover-places"),
 
   query: z
     .string()
@@ -57,7 +57,7 @@ export const tomtomDiscoverPlacesSchema = {
 export type DiscoverPlacesParams = z.input<z.ZodObject<typeof tomtomDiscoverPlacesSchema>>;
 
 export const tomtomLocatePlaceSchema = {
-  analyse: analyseSchema,
+  analyse: analyseSchemaFor("tomtom-locate-place"),
 
   query: z.string().describe("The place to locate — a single named place, address or landmark."),
   queryAs: queryAsSchema,

--- a/src/schemas/search/discoverPlacesSchema.ts
+++ b/src/schemas/search/discoverPlacesSchema.ts
@@ -18,9 +18,12 @@ import { z } from "zod";
 import { queryAsSchema } from "../../tools/shared/inputs/location-input";
 import { POI_CATEGORIES_DOC } from "../../tools/shared/inputs/resolve-poi-categories";
 import { whereSchema } from "../../tools/shared/inputs/resolve-where";
+import { analyseSchema } from "../shared/analyseSchema";
 import { uiVisibilityParam } from "./common";
 
 export const tomtomDiscoverPlacesSchema = {
+  analyse: analyseSchema,
+
   query: z
     .string()
     .optional()
@@ -41,7 +44,7 @@ export const tomtomDiscoverPlacesSchema = {
     .describe(
       "Maximum results (1-100, default 10). Raise it when the question is about the SET rather " +
         "than a few examples — the full result set is held server-side either way, and " +
-        "so narrow the search rather than counting or grouping over what came back."
+        "so pass `analyse` to count or group over the full set instead of over what came back."
     ),
   language: z.string().optional().describe("IETF language tag for result names, e.g. 'nl-NL'."),
   countries: z
@@ -54,6 +57,8 @@ export const tomtomDiscoverPlacesSchema = {
 export type DiscoverPlacesParams = z.input<z.ZodObject<typeof tomtomDiscoverPlacesSchema>>;
 
 export const tomtomLocatePlaceSchema = {
+  analyse: analyseSchema,
+
   query: z.string().describe("The place to locate — a single named place, address or landmark."),
   queryAs: queryAsSchema,
   where: whereSchema

--- a/src/schemas/shared/analyseSchema.ts
+++ b/src/schemas/shared/analyseSchema.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * `analyse` — the field that turns a data tool into a question you can ask of it.
+ *
+ * Every data tool already computes far more than it returns; the response is a
+ * trimmed, capped projection of it. `analyse` runs JavaScript over the FULL result
+ * on the server and returns only what that code produces, so the answer is
+ * computed from all of the data while none of it crosses the conversation.
+ *
+ * Deliberately one field on every tool rather than a separate analysis tool:
+ * there is nothing held between calls to point an analysis tool AT. The code
+ * sees this call's result and nothing else.
+ */
+
+import { z } from "zod";
+
+/** The shared `analyse` field. Identical on every data tool that accepts one. */
+export const analyseSchema = z
+  .string()
+  .optional()
+  .describe(
+    "JavaScript to run over the FULL result of THIS call, on the server. Returns only what your " +
+      "code returns — the untrimmed data never enters the conversation. " +
+      "Use it whenever the answer needs more of the data than a response can show: counts and " +
+      "totals over the whole result set, groupings and breakdowns, top-N rankings, filtering on a " +
+      "field the trimmed response omits, or spatial work (distances, containment, corridors). " +
+      "Prefer it over reasoning from a truncated list — a total computed from a capped list is " +
+      "simply wrong. " +
+      "In scope: `features` (array of every result feature, untrimmed), `data` (the whole raw " +
+      "response), `turf` (geometry) and `h3` (hex grid). The code is a FUNCTION BODY and must " +
+      "`return` a JSON-serializable value — e.g. " +
+      "`return features.filter(f => f.properties.poi?.categorySet?.some(c => c.id === 7315)).length`. " +
+      "It runs against one call's result: to relate two tools' results, ask each its own question."
+  );

--- a/src/schemas/shared/analyseSchema.ts
+++ b/src/schemas/shared/analyseSchema.ts
@@ -26,22 +26,27 @@
  */
 
 import { z } from "zod";
+import { analyseDescriptionFor } from "./response-shapes";
 
-/** The shared `analyse` field. Identical on every data tool that accepts one. */
-export const analyseSchema = z
-  .string()
-  .optional()
-  .describe(
-    "JavaScript to run over the FULL result of THIS call, on the server. Returns only what your " +
-      "code returns — the untrimmed data never enters the conversation. " +
-      "Use it whenever the answer needs more of the data than a response can show: counts and " +
-      "totals over the whole result set, groupings and breakdowns, top-N rankings, filtering on a " +
-      "field the trimmed response omits, or spatial work (distances, containment, corridors). " +
-      "Prefer it over reasoning from a truncated list — a total computed from a capped list is " +
-      "simply wrong. " +
-      "In scope: `features` (array of every result feature, untrimmed), `data` (the whole raw " +
-      "response), `turf` (geometry) and `h3` (hex grid). The code is a FUNCTION BODY and must " +
-      "`return` a JSON-serializable value — e.g. " +
-      "`return features.filter(f => f.properties.poi?.categorySet?.some(c => c.id === 7315)).length`. " +
-      "It runs against one call's result: to relate two tools' results, ask each its own question."
-  );
+/**
+ * Builds the `analyse` field for one tool.
+ *
+ * Per-tool rather than shared, because the useful half of this description is the
+ * shape of THAT tool's result — and without it the model is writing a filter
+ * against a response it has never seen. See `response-shapes.ts`.
+ */
+export const analyseSchemaFor = (toolName: string) =>
+  z
+    .string()
+    .optional()
+    .describe(
+      "JavaScript to run over the FULL result of THIS call, on the server. Returns only what your " +
+        "code returns — the untrimmed data never enters the conversation. " +
+        "Use it whenever the answer needs more of the data than a response can show: counts and " +
+        "totals over the whole result set, groupings and breakdowns, top-N rankings, filtering on " +
+        "a field the trimmed response omits, or spatial work (distances, containment, corridors). " +
+        "Prefer it over reasoning from a truncated list — a total computed from a capped list is " +
+        "simply wrong. " +
+        `${analyseDescriptionFor(toolName)} ` +
+        "It runs against one call's result: to relate two tools' results, ask each its own question."
+    );

--- a/src/schemas/shared/response-shapes.ts
+++ b/src/schemas/shared/response-shapes.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * What each tool's UNTRIMMED result looks like, for code that queries it.
+ *
+ * Stateless code execution has a discoverability problem that is easy to miss:
+ * `analyse` runs in the SAME call that produces the data, so the model writes its
+ * filter having never seen a response. Without this, it guesses property paths —
+ * and measurably guesses wrong. The first version of the `analyse` field carried
+ * one example that pointed at `properties.poi.categorySet`, a field that does not
+ * exist on this surface; the real one is `properties.poi.categories[]`.
+ *
+ * Every path below was read off a live response rather than from the SDK's types,
+ * because the question is what the API actually returns today.
+ *
+ * The cost of holding these here is real and worth stating: a stateless surface
+ * has to publish them on EVERY tool that accepts code, in every `tools/list`,
+ * whether or not any code is ever run. A surface with dataset handles can put the
+ * same facts on its one analysis tool, keyed by kind — which is what the agent
+ * toolkit's `buildEntryKindSchemaDocs` does.
+ */
+
+/** Shared preamble: the bindings are the same whichever tool is being queried. */
+export const ANALYSE_BINDINGS =
+  "In scope: `features` (every result feature, untrimmed), `data` (the whole raw response), " +
+  "`turf` (geometry) and `h3` (hex grid). The code is a FUNCTION BODY and must `return` a " +
+  "JSON-serializable value.";
+
+/**
+ * Per-tool result shapes, keyed by MCP tool name.
+ *
+ * Kept terse on purpose — this text ships on every `tools/list`, so it names the
+ * fields a question is likely to need and the traps, not the whole schema.
+ */
+export const RESPONSE_SHAPES: Readonly<Record<string, string>> = {
+  "tomtom-discover-places":
+    "Result: { type, features[] }. Each feature: geometry { type:'Point', coordinates:[lng,lat] }; " +
+    "properties { score, poi { name, categories[] (STRINGS, e.g. 'restaurant'), localizedCategories[], " +
+    "phone, url, brands[] }, address { freeformAddress, municipality, postalCode, streetName, " +
+    "streetNumber, countryCode, countrySubdivision }, entryPoints[], openingHours, " +
+    "chargingPark { connectors[] { connector { type, currentType, ratedPowerKW, voltageV, currentA, " +
+    "chargingSpeed }, count }, availability { connectorAvailabilities[] { count }, " +
+    "chargingPointAvailability { count } } } }. " +
+    "Traps: categories are plain strings under poi.categories[] — there is no categorySet of ids; " +
+    "connector fields sit under the NESTED connectors[].connector, not connectors[] itself; " +
+    "openingHours is frequently an empty array.",
+
+  "tomtom-locate-place":
+    "Result: { type, features[], bbox }. Each feature: geometry (a Point, or Polygon/MultiPolygon " +
+    "when includeGeometry was set); bbox; properties { type, score, matchConfidence { score }, " +
+    "geographyType[], address { freeformAddress, municipality, countrySubdivision, " +
+    "countrySubdivisionName, countryCode, country } }.",
+
+  "tomtom-plan-route":
+    "Result: { type, bbox, features[] } with ONE feature per route. geometry is a LineString whose " +
+    "coordinates[] are [lng,lat] pairs — the full polyline. properties { index, " +
+    "summary { lengthInMeters, travelTimeInSeconds, trafficDelayInSeconds, trafficLengthInMeters, " +
+    "departureTime, arrivalTime }, sections { leg[], tunnel[], motorway[], urban[], pedestrian[], " +
+    "country[] { countryCodeISO3 }, speedLimit[] { maxSpeedLimitInKmh }, lowEmissionZone[], " +
+    "roadShields[] { roadShieldReferences[] { reference } }, " +
+    "importantRoadStretch[] { streetName, roadNumbers[] } } }. " +
+    "Every section entry carries startPointIndex/endPointIndex, which index into " +
+    "geometry.coordinates. Trap: turn-by-turn guidance is NOT part of this result, so a turn count " +
+    "cannot be derived from it.",
+
+  "tomtom-find-reachable-areas":
+    "Result: { type, features[] } — one Polygon feature per origin × budget. " +
+    "geometry { type:'Polygon', coordinates:[[[lng,lat], …]] }; properties { origin[], " +
+    "budget { type, value } }. Use turf.booleanPointInPolygon to test containment, and " +
+    "properties.budget to tell the rings apart.",
+
+  "tomtom-get-traffic":
+    "Result: { incidents[] } — the top-level array is `incidents`, NOT `features` (the `features` " +
+    "binding is populated from it, so either works in code). Each incident: geometry " +
+    "(LineString or Point); properties { id, iconCategory, magnitudeOfDelay (0-4), delay (SECONDS), " +
+    "length (METRES), from, to, roadNumbers[] (e.g. ['A10']), startTime, endTime, timeValidity, " +
+    "probabilityOfOccurrence, numberOfReports, events[] { code, description, iconCategory } }. " +
+    "Trap: roadNumbers is absent on incidents that are not on a numbered road, so guard it before " +
+    "grouping.",
+};
+
+/** The `analyse` field description for one tool: bindings, then that tool's shape. */
+export const analyseDescriptionFor = (toolName: string): string =>
+  `${ANALYSE_BINDINGS} ${RESPONSE_SHAPES[toolName] ?? ""}`.trim();

--- a/src/services/datasets/dataset-store.ts
+++ b/src/services/datasets/dataset-store.ts
@@ -39,6 +39,7 @@ import { createHash, randomBytes } from "node:crypto";
 import NodeCache from "node-cache";
 import type { ToolDataKind } from "../../tools/shared/tool-entry";
 import { logger } from "../../utils/logger";
+import { redactCredentials } from "../../utils/redact";
 import { getEffectiveApiKey } from "../api-key";
 import { type DatasetSummary, summarize } from "./summarize";
 
@@ -286,6 +287,9 @@ export function storeDataset(options: {
   provenance: DatasetProvenance;
 }): Dataset {
   const { data, kind = "unknown", provenance } = options;
+  // Stored data outlives the call and is redeemable by the app, so it is
+  // redacted here too rather than only at the sandbox boundary.
+  redactCredentials(data);
   const summary = summarize(data, kind);
   const dataset: Dataset = {
     id: `ds_${randomBytes(8).toString("hex")}`,

--- a/src/tools/services/discover-places.test.ts
+++ b/src/tools/services/discover-places.test.ts
@@ -43,7 +43,10 @@ vi.mock("../../services/datasets/dataset-store", () => ({
   storeDataset: mocks.storeDataset,
 }));
 
-vi.mock("../shared/inputs/resolve-where", () => ({
+vi.mock("../shared/inputs/resolve-where", async (importOriginal) => ({
+  // The pure name helpers are the real ones — locate-place's ranking IS the
+  // thing under test here, and stubbing them would test the stubs.
+  ...(await importOriginal<typeof import("../shared/inputs/resolve-where")>()),
   resolveWithin: vi.fn(),
   resolveNearby: vi.fn(),
   describeAreas: vi.fn(() => ""),
@@ -425,7 +428,7 @@ describe("locatePlaceHandler", () => {
 
   it('still passes a position bias for a "nearby" scope', async () => {
     const { resolveNearby } = await import("../shared/inputs/resolve-where");
-    vi.mocked(resolveNearby).mockResolvedValue({ position: [4.9, 52.37] } as never);
+    vi.mocked(resolveNearby).mockResolvedValue({ value: { position: [4.9, 52.37] } } as never);
 
     await locatePlaceHandler({
       query: "Dam Square",

--- a/src/tools/services/discover-places.ts
+++ b/src/tools/services/discover-places.ts
@@ -47,6 +47,7 @@ import {
 } from "../../services/search/searchService";
 import { handleApiError } from "../../utils/apiErrorHandler";
 import { logger } from "../../utils/logger";
+import { runToolQuery } from "../shared/analyse-result";
 import { inBatches, MAX_AREAS_SEARCHED } from "../shared/in-batches";
 import { resolvePoiCategories } from "../shared/inputs/resolve-poi-categories";
 import {
@@ -155,7 +156,7 @@ const mergeAreaResults = (
 };
 
 export async function discoverPlacesHandler(params: DiscoverPlacesParams): Promise<ToolResponse> {
-  const { query, where, language, countries, show_ui = true } = params;
+  const { query, where, language, countries, analyse, show_ui = true } = params;
   const limit = params.limit ?? DEFAULT_LIMIT;
 
   if (!query && !params.poiCategories?.length) {
@@ -296,6 +297,10 @@ export async function discoverPlacesHandler(params: DiscoverPlacesParams): Promi
     ) {
       result = await withEVAvailability(result as Parameters<typeof withEVAvailability>[0]);
     }
+
+    // An `analyse` asks a question OF this result instead of reading it, so it
+    // short-circuits the projection entirely — see shared/query-result.ts.
+    if (analyse) return runToolQuery(analyse, result, "Place discovery");
 
     const dataset = storeDataset({
       data: result,
@@ -529,7 +534,7 @@ const resolveLocateScope = async (
 };
 
 export async function locatePlaceHandler(params: LocatePlaceParams): Promise<ToolResponse> {
-  const { query, queryAs, where, includeGeometry = false, show_ui = true } = params;
+  const { query, queryAs, where, includeGeometry = false, analyse, show_ui = true } = params;
   logger.info({ query, queryAs, includeGeometry }, "Locate place");
 
   try {
@@ -587,6 +592,10 @@ export async function locatePlaceHandler(params: LocatePlaceParams): Promise<Too
       (geoResult.status === "fulfilled" ? geoResult.value : undefined) ??
       {};
     const response = { ...(envelope as object), features };
+
+    // An `analyse` asks a question OF this result instead of reading it, so it
+    // short-circuits the projection entirely — see shared/query-result.ts.
+    if (analyse) return runToolQuery(analyse, response, "Place lookup");
 
     const dataset = storeDataset({
       data: response,

--- a/src/tools/services/discover-places.ts
+++ b/src/tools/services/discover-places.ts
@@ -53,9 +53,12 @@ import { resolvePoiCategories } from "../shared/inputs/resolve-poi-categories";
 import {
   DEFAULT_NEARBY_RADIUS_METERS,
   describeAreas,
+  inNamedArea,
+  normaliseName,
   type ResolvedArea,
   resolveNearby,
   resolveWithin,
+  splitNamedQuery,
 } from "../shared/inputs/resolve-where";
 import { trimSearchResponse } from "../shared/response-trimmer";
 import type { ToolResponse } from "../shared/tool-entry";
@@ -234,13 +237,16 @@ export async function discoverPlacesHandler(params: DiscoverPlacesParams): Promi
       duplicateHits = merged.duplicates;
       result = merged.response;
     } else if (where?.mode === "nearby") {
-      const bias = await resolveNearby(where);
+      const resolvedBias = await resolveNearby(where);
+      // A bias that cannot be resolved is fatal now. Widening here is what
+      // answered "near Dam Square, Amsterdam" with Leesburg, Virginia.
+      if ("error" in resolvedBias) return fail(resolvedBias.error);
+      const bias = resolvedBias.value;
       scope = bias.position
         ? `within ${bias.radiusMeters}m of ${bias.label ?? bias.position.join(", ")}`
-        : "no bias (unresolvable point)";
+        : "no bias";
 
       if (!bias.position) {
-        // No bias resolved: widen rather than fail (see resolveNearby).
         result = await fuzzySearch(query ?? "", {
           limit,
           ...(categories.resolved && { poiCategories: categories.resolved }),
@@ -362,33 +368,6 @@ export async function discoverPlacesHandler(params: DiscoverPlacesParams): Promi
   }
 }
 
-/**
- * Splits "Dam Square, Amsterdam" into the thing being looked for and the place
- * that qualifies it.
- *
- * The tail is what stops a global index from answering in the wrong country.
- * Unscoped, "Dam Square, Amsterdam" geocodes to Mill Dam Place in Leesburg,
- * Virginia and "Eiffel Tower, Paris" finds Paris, Texas — the user wrote the
- * disambiguator into the query and nothing was reading it.
- */
-const splitLocateQuery = (query: string): { subject: string; area?: string } => {
-  const parts = query
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length < 2) return { subject: query.trim() };
-  return { subject: parts[0], area: parts.slice(1).join(", ") };
-};
-
-/** Case-, accent- and punctuation-insensitive form, for comparing names. */
-const normaliseName = (value: string): string =>
-  value
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}]+/gu, " ")
-    .trim();
-
 interface LocateCandidate {
   properties?: {
     type?: string;
@@ -400,25 +379,6 @@ interface LocateCandidate {
 
 const locateLabel = (feature: LocateCandidate): string =>
   feature.properties?.poi?.name ?? feature.properties?.address?.freeformAddress ?? "(unnamed)";
-
-/**
- * Whether a candidate sits in the area the query named.
- *
- * Read off the address text rather than geometry, because this exists for the
- * case where the area could NOT be resolved to a box — a slow or failing
- * geocode, which happens — and an unscoped index will happily answer "Dam
- * Square, Amsterdam" with Mill Dam Place, Leesburg, Virginia. Without this the
- * fallback ranks that US street above a hotel actually in Amsterdam, which is a
- * worse answer than the one this ranking replaced.
- */
-const inNamedArea = (feature: LocateCandidate, area: string | undefined): boolean => {
-  if (!area) return true;
-  const address = feature.properties?.address;
-  const haystack = normaliseName(
-    [address?.freeformAddress, address?.municipality, address?.country].filter(Boolean).join(" ")
-  );
-  return haystack.length === 0 || haystack.includes(normaliseName(area));
-};
 
 /**
  * Orders candidates by how well each one IS the place that was asked for.
@@ -518,7 +478,11 @@ const resolveLocateScope = async (
     return {};
   }
 
-  if (where?.mode === "nearby") return { bias: (await resolveNearby(where)).position };
+  if (where?.mode === "nearby") {
+    const nearby = await resolveNearby(where);
+    if ("error" in nearby) return { error: nearby.error };
+    return { bias: nearby.value.position };
+  }
 
   if (!area) return {};
   // Best effort. A tail that is not a place ("Rijksmuseum, the one near the
@@ -538,7 +502,7 @@ export async function locatePlaceHandler(params: LocatePlaceParams): Promise<Too
   logger.info({ query, queryAs, includeGeometry }, "Locate place");
 
   try {
-    const { subject, area } = splitLocateQuery(query);
+    const { subject, area } = splitNamedQuery(query);
     const scope = await resolveLocateScope(where, area);
     if (scope.error) return fail(scope.error);
     const { bias, boundingBox } = scope;

--- a/src/tools/services/plan-route.test.ts
+++ b/src/tools/services/plan-route.test.ts
@@ -329,7 +329,7 @@ describe("getTrafficHandler", () => {
     // Computing a total from a truncated list is the exact fabrication the
     // capability benchmark measures; the response has to say so.
     expect(body.truncationNote).toContain("10 most severe of 500");
-    expect(body.truncationNote).toContain("narrow the area");
+    expect(body.truncationNote).toContain("`analyse`");
     // …but it must also say what the visible rows CAN answer. The cap keeps the
     // most severe rather than an arbitrary slice, and a note that said only
     // "it is a sample" had the agent refuse to name the worst incident at all.

--- a/src/tools/services/plan-route.ts
+++ b/src/tools/services/plan-route.ts
@@ -46,6 +46,7 @@ import {
 import { getTrafficIncidents } from "../../services/traffic/trafficService";
 import { handleApiError } from "../../utils/apiErrorHandler";
 import { logger } from "../../utils/logger";
+import { runToolQuery } from "../shared/analyse-result";
 import { inBatches, MAX_AREAS_SEARCHED } from "../shared/in-batches";
 import { resolveLocationInputs } from "../shared/inputs/location-input";
 import type { ResolvedArea } from "../shared/inputs/resolve-where";
@@ -73,7 +74,7 @@ const ok = (body: unknown, pretty = true): ToolResponse => ({
 // ---------------------------------------------------------------------------
 
 export async function planRouteHandler(params: PlanRouteParams): Promise<ToolResponse> {
-  const { locations, ev, show_ui = true, ...options } = params;
+  const { locations, ev, analyse, show_ui = true, ...options } = params;
 
   const resolved = await resolveLocationInputs(locations, "location");
   if ("error" in resolved) return fail(resolved.error);
@@ -93,6 +94,10 @@ export async function planRouteHandler(params: PlanRouteParams): Promise<ToolRes
           ...(options as Record<string, unknown>),
         } as Parameters<typeof calculateEVRoute>[0])
       : await getRoute(positions, options as Parameters<typeof getRoute>[1]);
+
+    // An `analyse` asks a question OF this result instead of reading it, so it
+    // short-circuits the projection entirely — see shared/query-result.ts.
+    if (analyse) return runToolQuery(analyse, result, "Route planning");
 
     const dataset = storeDataset({
       data: result,
@@ -140,7 +145,7 @@ const budgetField = (type: string): string =>
 export async function findReachableAreasHandler(
   params: FindReachableAreasParams
 ): Promise<ToolResponse> {
-  const { origins, budgets, show_ui = true, ...options } = params;
+  const { origins, budgets, analyse, show_ui = true, ...options } = params;
 
   const resolved = await resolveLocationInputs(origins, "origin");
   if ("error" in resolved) return fail(resolved.error);
@@ -170,6 +175,10 @@ export async function findReachableAreasHandler(
       return fc.type === "Feature" ? [result] : [];
     });
     const collection = { type: "FeatureCollection" as const, features };
+
+    // An `analyse` asks a question OF this result instead of reading it, so it
+    // short-circuits the projection entirely — see shared/query-result.ts.
+    if (analyse) return runToolQuery(analyse, collection, "Reachable areas");
 
     const dataset = storeDataset({
       data: collection,
@@ -406,6 +415,7 @@ const describeCoverage = (coverage: {
 export async function getTrafficHandler(params: GetTrafficParams): Promise<ToolResponse> {
   const {
     where,
+    analyse,
     show_ui = true,
     categoryFilter,
     timeValidityFilter,
@@ -472,6 +482,10 @@ export async function getTrafficHandler(params: GetTrafficParams): Promise<ToolR
         : mergeIncidents(succeeded);
     const result = merged as { incidents?: unknown[] };
 
+    // An `analyse` asks a question OF this result instead of reading it, so it
+    // short-circuits the projection entirely — see shared/query-result.ts.
+    if (analyse) return runToolQuery(analyse, result, "Traffic");
+
     const dataset = storeDataset({
       data: result,
       kind: "incidents",
@@ -505,8 +519,8 @@ export async function getTrafficHandler(params: GetTrafficParams): Promise<ToolR
           truncationNote:
             `Showing the ${shown} most severe of ${total} incidents, ranked by delay magnitude. ` +
             "The worst ones ARE above, so ranking questions — the single worst, the top few — are " +
-            "answerable from this list. Totals, counts and per-road breakdowns are NOT — narrow the " +
-            "area and ask again rather than computing them from these rows.",
+            "answerable from this list. Totals, counts and per-road breakdowns are NOT — re-run " +
+            "this call with `analyse` and the code sees every incident, not just these rows.",
         }),
         _meta: datasetMeta(dataset, show_ui),
       },

--- a/src/tools/services/plan-route.ts
+++ b/src/tools/services/plan-route.ts
@@ -314,7 +314,9 @@ type TrafficTargets =
  */
 const resolveTrafficTargets = async (where: GetTrafficParams["where"]): Promise<TrafficTargets> => {
   if (where.mode === "nearby") {
-    const bias = await resolveNearby(where);
+    const resolved = await resolveNearby(where);
+    if ("error" in resolved) return { error: resolved.error };
+    const bias = resolved.value;
     if (!bias.position) {
       return {
         error:

--- a/src/tools/shared/analyse-result.test.ts
+++ b/src/tools/shared/analyse-result.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { featuresOf, runToolQuery } from "./analyse-result";
+
+const parse = (result: { content: { text: string }[] }) =>
+  JSON.parse(result.content[0].text) as Record<string, never>;
+
+const fc = (n: number) => ({
+  type: "FeatureCollection",
+  features: Array.from({ length: n }, (_, i) => ({
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [4 + i / 100, 52] },
+    properties: { power: i * 10 },
+  })),
+});
+
+describe("featuresOf", () => {
+  it("reads whichever envelope a tool result uses", () => {
+    expect(featuresOf(fc(3))).toHaveLength(3);
+    expect(featuresOf({ incidents: [1, 2] })).toHaveLength(2);
+    expect(featuresOf({ type: "Feature" })).toHaveLength(1);
+    expect(featuresOf(null)).toHaveLength(0);
+  });
+});
+
+describe("runToolQuery", () => {
+  it("computes over every feature, not the ones a response would show", async () => {
+    // The point of the phase: 500 features never cross the conversation, and the
+    // count is still right.
+    const result = await runToolQuery("return features.length", fc(500), "Traffic");
+
+    expect(result.isError).toBeUndefined();
+    const body = parse(result as never);
+    expect(body.analysis).toBe(500);
+    expect(body.queriedOver).toMatchObject({ tool: "Traffic", features: 500 });
+  });
+
+  it("returns only the computed value, never the data it ran over", async () => {
+    const result = await runToolQuery(
+      "return features.filter((f) => f.properties.power >= 50).length",
+      fc(10),
+      "Place discovery"
+    );
+
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    expect(parse(result as never).analysis).toBe(5);
+    expect(text).not.toContain("coordinates");
+  });
+
+  it("has turf in scope for spatial questions", async () => {
+    const result = await runToolQuery(
+      "return Math.round(turf.distance(features[0], features[9], { units: 'kilometers' }))",
+      fc(10),
+      "Place discovery"
+    );
+
+    expect(typeof parse(result as never).analysis).toBe("number");
+  });
+
+  it("reports code that returns nothing rather than answering with null", async () => {
+    const result = await runToolQuery("features.length", fc(3), "Traffic");
+
+    expect(result.isError).toBe(true);
+    expect(parse(result as never).error).toContain("must return a value");
+  });
+
+  it("reports a runtime failure as an error, not an answer", async () => {
+    const result = await runToolQuery("return nope.missing", fc(3), "Traffic");
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/shared/analyse-result.ts
+++ b/src/tools/shared/analyse-result.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Runs a tool's `analyse` code over that tool's own fresh result.
+ *
+ * The stateless half of the agent toolkit's `analyseData`: the same sandbox and
+ * the same injected globals, but the data comes from the call in progress rather
+ * than from a stored entry. Nothing is held between calls, so there is no handle
+ * to pass, nothing to expire, and no id for the model to keep track of.
+ *
+ * The cost of that is real and worth naming: the code sees ONE tool's result. A
+ * question spanning two tools ("which of these chargers is inside that isochrone")
+ * cannot be expressed here — that needs handles, which is the next phase.
+ */
+
+import * as turf from "@turf/turf";
+import * as h3 from "h3-js";
+import { logger } from "../../utils/logger";
+import { processSandboxExecutor, runSandboxedFn, validateAnalysisResult } from "./sandbox";
+import type { ToolResponse } from "./tool-entry";
+
+/**
+ * Injected parameter names, in the order the sandbox receives them.
+ *
+ * `turf` and `h3` are listed so the body has them in scope, but their values are
+ * supplied INSIDE the worker — function namespaces cannot cross a
+ * structured-clone boundary. The imports above keep this module's real
+ * dependencies declared.
+ */
+const SANDBOX_PARAMS = ["features", "data", "turf", "h3"] as const;
+
+/** Pulls the feature array out of whichever envelope a tool result uses. */
+export function featuresOf(data: unknown): unknown[] {
+  if (!data || typeof data !== "object") return [];
+  const obj = data as Record<string, unknown>;
+  if (Array.isArray(obj.features)) return obj.features;
+  if (Array.isArray(obj.incidents)) return obj.incidents;
+  if (obj.type === "Feature") return [obj];
+  return [];
+}
+
+/**
+ * Executes `code` over `data` and shapes the tool response.
+ *
+ * Returns the computed value INSTEAD of the tool's normal projection — a query
+ * is a different question, not an addition to the usual answer, and returning
+ * both would put back exactly the payload the query exists to avoid.
+ *
+ * @param code   the model-supplied function body
+ * @param data   the tool's full, untrimmed result
+ * @param verb   human-readable action, used in error strings and logs
+ */
+export async function runToolQuery(
+  code: string,
+  data: unknown,
+  verb: string
+): Promise<ToolResponse> {
+  const features = featuresOf(data);
+  const started = Date.now();
+
+  const result = await runSandboxedFn(
+    code,
+    SANDBOX_PARAMS,
+    // turf / h3 slots are filled inside the worker; see SANDBOX_PARAMS.
+    [features, data, turf, h3],
+    verb,
+    processSandboxExecutor
+  );
+  const elapsedMs = Date.now() - started;
+
+  if ("error" in result) {
+    logger.warn({ verb, elapsedMs, error: result.error }, "Analysis failed");
+    return {
+      content: [{ type: "text", text: JSON.stringify({ error: result.error }) }],
+      isError: true,
+    };
+  }
+
+  const validated = validateAnalysisResult(result.value, "json");
+  if ("error" in validated) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ error: validated.error }) }],
+      isError: true,
+    };
+  }
+
+  logger.info({ verb, elapsedMs, featureCount: features.length }, "Analysis complete");
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            analysis: validated.value,
+            // What the code actually ran over, so a surprising number can be
+            // traced to the input rather than assumed to be a bug in the code.
+            queriedOver: { tool: verb, features: features.length },
+            elapsedMs,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/src/tools/shared/analyse-result.ts
+++ b/src/tools/shared/analyse-result.ts
@@ -28,6 +28,7 @@
 import * as turf from "@turf/turf";
 import * as h3 from "h3-js";
 import { logger } from "../../utils/logger";
+import { redactCredentials } from "../../utils/redact";
 import { processSandboxExecutor, runSandboxedFn, validateAnalysisResult } from "./sandbox";
 import type { ToolResponse } from "./tool-entry";
 
@@ -67,6 +68,10 @@ export async function runToolQuery(
   data: unknown,
   verb: string
 ): Promise<ToolResponse> {
+  // The SDK echoes request params — including the API key — into feature
+  // properties. Strip them before model-authored code can read them.
+  redactCredentials(data);
+
   const features = featuresOf(data);
   const started = Date.now();
 

--- a/src/tools/shared/inputs/resolve-where.test.ts
+++ b/src/tools/shared/inputs/resolve-where.test.ts
@@ -17,8 +17,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGeocode = vi.fn();
+const mockPoiSearch = vi.fn();
 
-vi.mock("../../../services/search/searchService", () => ({ geocodeAddress: mockGeocode }));
+vi.mock("../../../services/search/searchService", () => ({
+  geocodeAddress: mockGeocode,
+  poiSearch: mockPoiSearch,
+}));
 vi.mock("../../../services/api-key", () => ({ getEffectiveApiKey: () => "key-test" }));
 vi.mock("../../../utils/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -120,15 +124,13 @@ describe("resolveNearby", () => {
   });
 
   it("uses an explicit position and defaults the radius", async () => {
-    expect(await resolveNearby({ mode: "nearby", position: [4.9, 52.37] })).toEqual({
-      position: [4.9, 52.37],
-      radiusMeters: 1000,
-    });
+    const bias = await resolveNearby({ mode: "nearby", position: [4.9, 52.37] });
+    expect("value" in bias && bias.value).toEqual({ position: [4.9, 52.37], radiusMeters: 1000 });
   });
 
   it("honours an explicit radius", async () => {
     const bias = await resolveNearby({ mode: "nearby", position: [0, 0], radiusMeters: 250 });
-    expect(bias.radiusMeters).toBe(250);
+    expect("value" in bias && bias.value.radiusMeters).toBe(250);
   });
 
   it("resolves a query to a bias point", async () => {
@@ -137,16 +139,53 @@ describe("resolveNearby", () => {
         { type: "Feature", geometry: { type: "Point", coordinates: [4.9, 52.4] }, properties: {} },
       ],
     });
+    mockPoiSearch.mockResolvedValue({ features: [] });
     const bias = await resolveNearby({ mode: "nearby", query: "Amsterdam Centraal" });
-    expect(bias.position).toEqual([4.9, 52.4]);
+    expect("value" in bias && bias.value.position).toEqual([4.9, 52.4]);
   });
 
-  // Unlike `within`, a missing bias widens the search rather than failing it.
-  it("treats an unresolvable bias as no bias, not an error", async () => {
+  it("takes the POI index's answer for a named landmark the geocoder misses", async () => {
+    // A square, station or landmark lives in the POI index, not the address one.
+    mockPoiSearch.mockResolvedValue({
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [4.893, 52.373] },
+          properties: { poi: { name: "Dam Square" }, address: { municipality: "Amsterdam" } },
+        },
+      ],
+    });
+    mockGeocode.mockResolvedValue({ features: [] });
+    const bias = await resolveNearby({ mode: "nearby", query: "Dam Square, Amsterdam" });
+    expect("value" in bias && bias.value.position).toEqual([4.893, 52.373]);
+  });
+
+  // The regression this function was rewritten for: an unscoped index answers
+  // "Dam Square, Amsterdam" with Mill Dam Place, Leesburg, Virginia.
+  it("discards a candidate that contradicts the area the query named", async () => {
+    mockPoiSearch.mockResolvedValue({ features: [] });
+    mockGeocode.mockResolvedValue({
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [-77.56, 39.11] },
+          properties: {
+            address: { freeformAddress: "Mill Dam Place, Leesburg, VA", country: "United States" },
+          },
+        },
+      ],
+    });
+    const bias = await resolveNearby({ mode: "nearby", query: "Dam Square, Amsterdam" });
+    expect("error" in bias && bias.error).toContain("Could not resolve");
+  });
+
+  // Reversed deliberately: widening produced results on the wrong continent
+  // while the response still reported the scope it had been asked for.
+  it("fails rather than searching unbiased when nothing resolves", async () => {
     mockGeocode.mockRejectedValue(new Error("upstream down"));
+    mockPoiSearch.mockRejectedValue(new Error("upstream down"));
     const bias = await resolveNearby({ mode: "nearby", query: "nowhere" });
-    expect(bias.position).toBeUndefined();
-    expect(bias.radiusMeters).toBe(1000);
+    expect("error" in bias && bias.error).toContain("Could not resolve");
   });
 });
 

--- a/src/tools/shared/inputs/resolve-where.ts
+++ b/src/tools/shared/inputs/resolve-where.ts
@@ -39,7 +39,7 @@
 import type { BBox } from "@tomtom-org/maps-sdk/core";
 import type { Position } from "geojson";
 import { z } from "zod";
-import { geocodeAddress } from "../../../services/search/searchService";
+import { geocodeAddress, poiSearch } from "../../../services/search/searchService";
 
 /** Where a resolved area came from, for reporting back what was actually searched. */
 export type AreaSource = "boundingBox" | "query" | "geometry" | "dataset" | "route";
@@ -234,27 +234,138 @@ export const DEFAULT_NEARBY_RADIUS_METERS = 1000;
  * Unlike `within`, an unresolvable input here is NOT fatal — a missing bias means
  * a wider search, not a failed one, which matches how the toolkit treats it.
  */
-export async function resolveNearby(where: NearbyWhere): Promise<ResolvedBias> {
+/**
+ * Case-, accent- and punctuation-insensitive form, for comparing place names.
+ *
+ * Shared with `discover-places`, which needs the same comparison when it ranks
+ * candidates for `locate-place`.
+ */
+export const normaliseName = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+
+/**
+ * Splits "Dam Square, Amsterdam" into the thing being looked for and the place
+ * that qualifies it. The tail is what stops a global index answering in the
+ * wrong country.
+ */
+export const splitNamedQuery = (query: string): { subject: string; area?: string } => {
+  const parts = query
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length < 2) return { subject: query.trim() };
+  return { subject: parts[0], area: parts.slice(1).join(", ") };
+};
+
+interface NamedCandidate {
+  properties?: {
+    address?: { freeformAddress?: string; municipality?: string; country?: string };
+    poi?: { name?: string };
+  };
+  geometry?: { coordinates?: unknown };
+}
+
+/** Whether a candidate sits in the area the query named, read off its address text. */
+export const inNamedArea = (feature: NamedCandidate, area: string | undefined): boolean => {
+  if (!area) return true;
+  const address = feature.properties?.address;
+  const haystack = normaliseName(
+    [address?.freeformAddress, address?.municipality, address?.country].filter(Boolean).join(" ")
+  );
+  return haystack.length === 0 || haystack.includes(normaliseName(area));
+};
+
+const pointOf = (feature: NamedCandidate): Position | undefined => {
+  const coords = feature?.geometry?.coordinates;
+  return Array.isArray(coords) && typeof coords[0] === "number" ? (coords as Position) : undefined;
+};
+
+/**
+ * Resolves a place NAME to a point, consulting both indexes.
+ *
+ * The address geocoder alone is not enough and the failure is not subtle: asked
+ * for "Dam Square, Amsterdam" it returns Mill Dam Place in Leesburg, Virginia —
+ * measured, and the reason this function exists. A named square, station or
+ * landmark lives in the POI index; a street or a city lives in the geocoder; a
+ * `where.nearby.query` can be either and does not say which.
+ *
+ * So both are asked, and any candidate that contradicts the area the query
+ * named ("…, Amsterdam") is discarded rather than ranked. `locate-place` does a
+ * richer version of this for its own answer; this is the part a bias needs.
+ */
+const resolveNamedPoint = async (
+  query: string
+): Promise<{ position: Position; label: string } | undefined> => {
+  const { subject, area } = splitNamedQuery(query);
+
+  const settled = await Promise.allSettled([
+    poiSearch(subject, { limit: 5 }),
+    geocodeAddress(query, { limit: 5 }),
+  ]);
+
+  const candidates: NamedCandidate[] = [];
+  for (const outcome of settled) {
+    if (outcome.status !== "fulfilled") continue;
+    const features = (outcome.value as { features?: NamedCandidate[] }).features ?? [];
+    candidates.push(...features);
+  }
+
+  const inArea = candidates.filter((candidate) => inNamedArea(candidate, area));
+  for (const candidate of inArea) {
+    const position = pointOf(candidate);
+    if (position) {
+      return {
+        position,
+        label:
+          candidate.properties?.poi?.name ??
+          candidate.properties?.address?.freeformAddress ??
+          query,
+      };
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Resolves a `nearby` scope to a bias point.
+ *
+ * An unresolvable bias is a HARD failure, which reverses this function's
+ * original behaviour. It used to fall through to an unbiased search on the
+ * reasoning that a missing bias means a wider search rather than a failed one.
+ * Measured, that reasoning produced restaurants in Leesburg, Virginia for
+ * "within 800m of Dam Square, Amsterdam" — and the response still reported the
+ * scope it had been ASKED for, so nothing downstream could tell. A wider search
+ * is a defensible fallback; a search on the wrong continent, described as one on
+ * the right one, is not.
+ */
+export async function resolveNearby(
+  where: NearbyWhere
+): Promise<{ value: ResolvedBias } | { error: string }> {
   const radiusMeters = where.radiusMeters ?? DEFAULT_NEARBY_RADIUS_METERS;
 
   if (where.position) {
-    return { position: where.position as Position, radiusMeters };
+    return { value: { position: where.position as Position, radiusMeters } };
   }
 
   if (where.query) {
-    try {
-      const response = await geocodeAddress(where.query, { limit: 1 });
-      const feature = (response as { features?: unknown[] }).features?.[0];
-      const coords = (feature as { geometry?: { coordinates?: unknown } })?.geometry?.coordinates;
-      if (Array.isArray(coords) && typeof coords[0] === "number") {
-        return { position: coords as Position, radiusMeters, label: where.query };
-      }
-    } catch {
-      // A failed bias is not a failed search; fall through to no bias.
+    const resolved = await resolveNamedPoint(where.query);
+    if (!resolved) {
+      return {
+        error:
+          `Could not resolve "${where.query}" to a point to search around. Give ` +
+          "`where.position` as [longitude, latitude], or name the area with " +
+          '`where: { mode: "within", queries: [...] }` instead.',
+      };
     }
+    return { value: { position: resolved.position, radiusMeters, label: resolved.label } };
   }
 
-  return { radiusMeters };
+  return { value: { radiusMeters } };
 }
 
 /** What was actually searched, for reporting alongside results. */

--- a/src/tools/shared/sandbox/index.ts
+++ b/src/tools/shared/sandbox/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createProcessSandboxExecutor, processSandboxExecutor } from "./process-executor";
+export {
+  type AnalysisOutputFormat,
+  CHART_TYPES,
+  formatSandboxExecutionError,
+  isChartConfiguration,
+  runSandboxedFn,
+  type SandboxExecutor,
+  sandboxedGlobalShadows,
+  stripInjectedRedeclarations,
+  validateAnalysisResult,
+} from "./sandbox-code";

--- a/src/tools/shared/sandbox/process-executor.test.ts
+++ b/src/tools/shared/sandbox/process-executor.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * These are the tests that decide whether running model-authored code on this
+ * server is defensible. Each isolation claim in `process-executor.ts` gets an
+ * assertion here — a claim about a security boundary that nothing exercises is
+ * just a comment.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createProcessSandboxExecutor } from "./process-executor";
+import { runSandboxedFn } from "./sandbox-code";
+
+const executor = createProcessSandboxExecutor({ timeoutMs: 8_000 });
+
+const run = <T = unknown>(code: string, params: string[] = [], args: unknown[] = []) =>
+  runSandboxedFn<T>(code, params, args, "Analysis", executor);
+
+describe("ProcessSandboxExecutor", { timeout: 60_000 }, () => {
+  it("runs a body and returns its value", async () => {
+    const result = await run<number>("return 1 + 1;");
+    expect(result).toEqual({ value: 2 });
+  });
+
+  it("passes injected data through", async () => {
+    const result = await run<number>("return items.length;", ["items"], [[1, 2, 3]]);
+    expect(result).toEqual({ value: 3 });
+  });
+
+  it("provides turf inside the child", async () => {
+    const result = await run<number>(
+      "return Math.round(turf.distance([4.9, 52.37], [4.9, 52.38], { units: 'meters' }));",
+      ["turf"],
+      [undefined]
+    );
+    expect("value" in result && (result.value as number)).toBeGreaterThan(1000);
+  });
+
+  it("provides h3 inside the child", async () => {
+    const result = await run<string>("return h3.latLngToCell(52.37, 4.9, 7);", ["h3"], [undefined]);
+    expect("value" in result && typeof result.value).toBe("string");
+  });
+
+  it("supports top-level await", async () => {
+    const result = await run<number>("const v = await Promise.resolve(7); return v;");
+    expect(result).toEqual({ value: 7 });
+  });
+
+  // --- Isolation claims ------------------------------------------------------
+
+  it("kills an unbounded loop and explains why", async () => {
+    const started = Date.now();
+    const result = await run("while (true) {}");
+    expect("error" in result && result.error).toContain("timed out");
+    // The whole point: a spin cannot be stopped on the main thread at all.
+    expect(Date.now() - started).toBeLessThan(20_000);
+  });
+
+  it("survives an allocation loop instead of taking the server down", async () => {
+    const result = await run("const a = []; while (true) { a.push(new Array(1e6).fill(0)); }");
+    expect("error" in result).toBe(true);
+    // Either the heap cap or the wall clock catches it; both are acceptable.
+    expect("error" in result && /memory|timed out|terminated/i.test(result.error)).toBe(true);
+  });
+
+  it("blocks network access", async () => {
+    const result = await run("return typeof fetch;");
+    expect(result).toEqual({ value: "undefined" });
+  });
+
+  it("blocks process access", async () => {
+    const result = await run("return typeof process;");
+    expect(result).toEqual({ value: "undefined" });
+  });
+
+  it("blocks require", async () => {
+    const result = await run("return typeof require;");
+    expect(result).toEqual({ value: "undefined" });
+  });
+
+  // The tests below deliberately USE the constructor-walk escape, because that
+  // is the realistic attacker and the shadows do not stop it. What must hold is
+  // that the worker options do.
+  const ESCAPE = 'const g = ({}).constructor.constructor("return globalThis")();';
+
+  it("documents that global shadowing is only a tripwire", async () => {
+    // Stated plainly in sandbox-code.ts; asserted here so nobody mistakes the
+    // shadows for the boundary. If this ever starts failing, the escape closed
+    // and the docs should be updated — it is not a regression.
+    const result = await run(`${ESCAPE} return typeof g.process;`);
+    expect(result).toEqual({ value: "object" });
+  });
+
+  it("gives the body no credentials even through the escape", async () => {
+    const result = await run(`${ESCAPE} return Object.keys(g.process.env);`);
+
+    const keys = ("value" in result ? result.value : []) as string[];
+    // `env: {}` is what enforces this, not the shadows. macOS injects
+    // `__CF_USER_TEXT_ENCODING` below the Node layer (a locale artifact, absent
+    // on Linux), so assert on WHAT is visible rather than on an empty count —
+    // a count assertion would be a platform trip-hazard for no extra safety.
+    for (const key of keys) expect(key).toBe("__CF_USER_TEXT_ENCODING");
+    for (const secret of [
+      "TOMTOM_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "AZURE_API_KEY",
+      "PATH",
+      "HOME",
+      "PWD",
+    ]) {
+      expect(keys, secret).not.toContain(secret);
+    }
+  });
+
+  it("denies filesystem reads even through the escape", async () => {
+    const result = await run(
+      `try { const fs = await import("node:fs"); fs.readFileSync("/etc/hosts"); return "ALLOWED"; }
+       catch (e) { return e.code ?? "threw"; }`
+    );
+    // Enforced by --permission. Verified to be ERR_ACCESS_DENIED, not a shadow.
+    expect(result).toEqual({ value: "ERR_ACCESS_DENIED" });
+  });
+
+  it("denies reading the repo's own .env", async () => {
+    const result = await run(
+      `try { const fs = await import("node:fs");
+             return fs.readFileSync(${JSON.stringify(`${process.cwd()}/.env`)}, "utf8").length > 0 ? "READ" : "EMPTY"; }
+       catch (e) { return e.code ?? "threw"; }`
+    );
+    // The reason this executor is a process and not a worker thread: with a
+    // worker, this read SUCCEEDED (the cwd stays readable under worker-level
+    // --permission) and handed the body the server's API key.
+    expect(result).toEqual({ value: "ERR_ACCESS_DENIED" });
+  });
+
+  it("denies spawning a subprocess", async () => {
+    const result = await run(
+      `try { const cp = await import("node:child_process"); cp.execSync("echo hi"); return "ALLOWED"; }
+       catch (e) { return e.code ?? "threw"; }`
+    );
+    expect(result).toEqual({ value: "ERR_ACCESS_DENIED" });
+  });
+
+  it("denies spawning a nested worker", async () => {
+    const result = await run(
+      `try { const wt = await import("node:worker_threads"); new wt.Worker("", { eval: true }); return "ALLOWED"; }
+       catch (e) { return e.code ?? "threw"; }`
+    );
+    expect("value" in result && result.value).not.toBe("ALLOWED");
+  });
+
+  it("cannot read the server's source tree", async () => {
+    const result = await run(
+      `try { const fs = await import("node:fs");
+             return fs.readFileSync(${JSON.stringify(`${process.cwd()}/package.json`)}, "utf8").slice(0, 4); }
+       catch (e) { return e.code ?? "threw"; }`
+    );
+    expect(result).toEqual({ value: "ERR_ACCESS_DENIED" });
+  });
+
+  it("still loads turf and h3 despite the filesystem denial", async () => {
+    // The permission grant is scoped to the two library package roots; if that
+    // scoping breaks, every analysis fails rather than silently degrading.
+    const result = await run(
+      "return [typeof turf.area, typeof h3.latLngToCell].join(',');",
+      ["turf", "h3"],
+      [undefined, undefined]
+    );
+    expect(result).toEqual({ value: "function,function" });
+  });
+
+  it("KNOWN GAP: network egress is not blocked", async () => {
+    // Node's permission model does not cover sockets. Asserted so the gap is
+    // visible in the test output rather than living only in a comment — see the
+    // residual-risk note in worker-executor.ts. Closing it needs a container
+    // egress policy.
+    const result = await run(`${ESCAPE} return typeof g.fetch;`);
+    expect(result).toEqual({ value: "function" });
+  });
+
+  it("cannot mutate data the server still holds", async () => {
+    const held = { features: [{ properties: { name: "original" } }] };
+    const result = await run(
+      "data.features[0].properties.name = 'mutated'; return data.features[0].properties.name;",
+      ["data"],
+      [held]
+    );
+    // The body saw its own copy (JSON across the process boundary)…
+    expect(result).toEqual({ value: "mutated" });
+    // …and the server's object is untouched.
+    expect(held.features[0].properties.name).toBe("original");
+  });
+
+  // --- Error reporting -------------------------------------------------------
+
+  it("reports a syntax error as an actionable message", async () => {
+    const result = await run("return {;");
+    expect("error" in result && result.error).toMatch(/Unexpected|not valid JavaScript/);
+    expect("error" in result && result.error).toContain("Hint:");
+  });
+
+  it("hints on a turf typo", async () => {
+    const result = await run("return turf.notARealFunction();", ["turf"], [undefined]);
+    expect("error" in result && result.error).toContain("turfjs.org");
+  });
+
+  it("hints when the code reaches for another tool", async () => {
+    const result = await run("return await tools.discoverPlaces();");
+    expect("error" in result && result.error).toContain("dataset_ids");
+  });
+
+  it("strips an LLM's habitual require of an injected library", async () => {
+    // Would otherwise be a parse-time "already been declared" before the body runs.
+    const result = await run(
+      "const turf = require('@turf/turf');\nreturn typeof turf.area;",
+      ["turf"],
+      [undefined]
+    );
+    expect(result).toEqual({ value: "function" });
+  });
+
+  it("runs concurrent analyses independently", async () => {
+    const results = await Promise.all([run("return 1;"), run("return 2;"), run("return 3;")]);
+    expect(results).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
+  });
+});

--- a/src/tools/shared/sandbox/process-executor.ts
+++ b/src/tools/shared/sandbox/process-executor.ts
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * `ProcessSandboxExecutor` — runs LLM-authored code in a jailed child process.
+ *
+ * ## Why a process and not a worker thread
+ *
+ * This started as a `worker_threads` executor, which is the obvious choice: it is
+ * faster to start and data crosses by structured clone. It was replaced after
+ * measuring what its isolation actually bought, and the measurement is worth
+ * recording because the failure was silent.
+ *
+ * Node's permission model (`--permission`) can be passed per-thread via
+ * `execArgv`, and it looks like it works: `process.permission` is present and
+ * reading `/etc/hosts` fails with `ERR_ACCESS_DENIED`. But a worker cannot have
+ * its own working directory, and worker-level `--permission` leaves the cwd
+ * readable. In this repo that meant a sandboxed body could read
+ * `<repo>/.env` — the server's own TomTom API key — while `/etc/hosts` was
+ * correctly denied. A boundary that blocks the harmless path and allows the
+ * credential is worse than no boundary, because it reads as safe.
+ *
+ * A child process has its own `cwd`. Pointed at an empty temp directory with
+ * `--permission` and a read grant covering only `node_modules`, the same probes
+ * come back denied — including `.env`. That is the whole reason for the extra
+ * ~50ms of process startup.
+ *
+ * ## What is enforced, measured rather than assumed
+ *
+ * | Capability | Status |
+ * | --- | --- |
+ * | Read the server's `.env` / any repo file | **denied** (`ERR_ACCESS_DENIED`) |
+ * | Read anything outside `node_modules` | **denied** |
+ * | Read env vars / credentials | **denied** — `env: {}` |
+ * | Spawn a subprocess | **denied** (`ERR_ACCESS_DENIED`) |
+ * | Exceed the heap cap | **denied** — `--max-old-space-size` |
+ * | Run past the timeout | **denied** — `SIGKILL` |
+ * | **Network egress** | **NOT denied** — see below |
+ *
+ * The global shadowing in `sandbox-code.ts` is a tripwire and nothing more: a
+ * constructor walk (`({}).constructor.constructor("return globalThis")()`)
+ * reaches the real `globalThis`. Verified. What makes the table hold is the
+ * process options, not the shadows.
+ *
+ * **Residual risk: network.** Node's permission model does not cover sockets, so
+ * `fetch` stays reachable through that walk. A body could POST the dataset it was
+ * handed to an external host. It cannot reach another caller's datasets (each
+ * analysis only receives datasets its own principal owns) nor the server's
+ * credentials, so the exposure is bounded by what that caller could already read
+ * through the tool surface. Closing it needs an egress policy at the container
+ * level — a deployment decision — and that is the one thing to settle before
+ * enabling this on a shared endpoint.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { logger } from "../../../utils/logger";
+import {
+  formatSandboxExecutionError,
+  type SandboxExecutor,
+  sandboxedGlobalShadows,
+} from "./sandbox-code";
+
+/** Wall-clock ceiling for one analysis. Past this the child is SIGKILLed. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Heap ceiling. Generous enough for turf over ~100k features. */
+const MAX_HEAP_MB = 512;
+
+/** Cap on the JSON the child may write back, so a runaway result can't fill memory. */
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+interface SandboxPaths {
+  /** `require`-able absolute paths for the injected libraries. */
+  libs: { turf: string; h3: string };
+  /** The single directory the child is allowed to read. */
+  readableDir: string;
+}
+
+let paths: SandboxPaths | undefined;
+
+/**
+ * Resolves the library paths and the one directory the child may read.
+ *
+ * The grant is the `node_modules` ROOT, not each package directory: CJS
+ * resolution walks parent directories looking for `package.json`, so a
+ * package-scoped grant makes `require` fail with `ERR_ACCESS_DENIED` (measured).
+ * The root is still far narrower than the repo — it excludes `.env`, the source
+ * tree, and everything else on the machine.
+ */
+const resolvePaths = (): SandboxPaths => {
+  const require = createRequire(import.meta.url);
+  const turf = require.resolve("@turf/turf");
+  const h3 = require.resolve("h3-js");
+  // First `/node_modules/` segment: correct for both a pnpm store layout
+  // (…/node_modules/.pnpm/pkg/node_modules/pkg/…) and a flat npm one.
+  const marker = "/node_modules/";
+  const index = turf.indexOf(marker);
+  const readableDir = index === -1 ? turf : turf.slice(0, index + marker.length - 1);
+  return { libs: { turf, h3 }, readableDir };
+};
+
+/**
+ * The child program, as a `-e` script.
+ *
+ * CommonJS on purpose: the child runs with no package.json in scope (its cwd is
+ * an empty jail), so `require` of an absolute path is the dependable way in.
+ * Everything it needs arrives on stdin — it opens no files and reads no argv.
+ */
+const CHILD_SOURCE = /* js */ `
+const chunks = [];
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", async () => {
+  let reply = { ok: false, name: "Error", message: "sandbox did not run" };
+  try {
+    const { code, paramNames, args, shadows, libs } = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+    // Namespaces cannot cross a JSON boundary, so they are required in here.
+    const provided = { turf: require(libs.turf), h3: require(libs.h3) };
+
+    const callArgs = paramNames.map((name, i) =>
+      Object.prototype.hasOwnProperty.call(provided, name) ? provided[name] : args[i]
+    );
+
+    const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+    // Never shadow a name the caller injects — a duplicate formal parameter
+    // would clobber the real value with undefined.
+    const active = shadows.filter((n) => !paramNames.includes(n));
+    const fn = new AsyncFunction(...paramNames, ...active, code);
+
+    const value = await fn(...callArgs, ...active.map(() => undefined));
+    reply = { ok: true, value };
+  } catch (error) {
+    reply = {
+      ok: false,
+      name: (error && error.name) || "Error",
+      message: (error && error.message) || String(error),
+    };
+  }
+  try {
+    process.stdout.write(JSON.stringify(reply));
+  } catch (error) {
+    // A value that will not serialise (circular, BigInt) must still come back as
+    // a usable error rather than an empty stdout the parent cannot explain.
+    process.stdout.write(
+      JSON.stringify({ ok: false, name: "TypeError", message: "could not be cloned: " + error.message })
+    );
+  }
+});
+`;
+
+export interface ProcessExecutorOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * Creates a {@link SandboxExecutor} that runs each body in a fresh jailed child.
+ *
+ * Fresh per call, deliberately: a reused process would carry prototype pollution
+ * or a leaked global from one caller's code into the next, which is exactly the
+ * property being bought here.
+ */
+export function createProcessSandboxExecutor(
+  options: ProcessExecutorOptions = {}
+): SandboxExecutor {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    run<Result = unknown>(
+      code: string,
+      paramNames: readonly string[],
+      args: readonly unknown[],
+      verb: string
+    ): Promise<{ value: Result } | { error: string }> {
+      return new Promise((resolve) => {
+        paths ??= resolvePaths();
+
+        // An empty directory as cwd is what makes the read grant meaningful: the
+        // child's working directory holds nothing worth reading.
+        let jail: string;
+        try {
+          jail = mkdtempSync(`${tmpdir()}/tomtom-mcp-sandbox-`);
+        } catch (error) {
+          resolve({ error: formatSandboxExecutionError(verb, error) });
+          return;
+        }
+
+        const payload = JSON.stringify({
+          code,
+          paramNames: [...paramNames],
+          // Library slots are filled in the child; sending `undefined` keeps the
+          // positions aligned without trying to serialise a namespace.
+          args: args.map((value, index) =>
+            paramNames[index] === "turf" || paramNames[index] === "h3" ? undefined : value
+          ),
+          shadows: [...sandboxedGlobalShadows],
+          libs: paths.libs,
+        });
+
+        const child = spawn(
+          process.execPath,
+          [
+            "--permission",
+            `--allow-fs-read=${paths.readableDir}`,
+            `--max-old-space-size=${MAX_HEAP_MB}`,
+            "-e",
+            CHILD_SOURCE,
+          ],
+          {
+            cwd: jail,
+            // No env at all: the body cannot read TOMTOM_API_KEY or anything else.
+            env: {},
+            stdio: ["pipe", "pipe", "pipe"],
+          }
+        );
+
+        let stdout = "";
+        let stderr = "";
+        let truncated = false;
+        let settled = false;
+
+        const cleanup = (): void => {
+          clearTimeout(timer);
+          try {
+            rmSync(jail, { recursive: true, force: true });
+          } catch {
+            // A leftover empty temp dir is harmless; never fail an analysis on it.
+          }
+        };
+
+        const finish = (outcome: { value: Result } | { error: string }): void => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          child.kill("SIGKILL");
+          resolve(outcome);
+        };
+
+        const timer = setTimeout(() => {
+          logger.warn({ verb, timeoutMs }, "Sandbox execution timed out — killing child process");
+          finish({
+            error:
+              `${verb} code execution timed out after ${timeoutMs}ms and was cancelled. ` +
+              "Hint: the code may contain an unbounded loop, or be doing O(N·M) work over a large " +
+              "dataset — pre-bucket points with `h3.latLngToCell` and compare only same-cell or " +
+              "neighbour-cell pairs to turn that into roughly O(N+M).",
+          });
+        }, timeoutMs);
+
+        child.stdout.on("data", (chunk: Buffer) => {
+          if (stdout.length + chunk.length > MAX_OUTPUT_BYTES) {
+            truncated = true;
+            child.kill("SIGKILL");
+            return;
+          }
+          stdout += chunk.toString("utf8");
+        });
+        child.stderr.on("data", (chunk: Buffer) => {
+          stderr = (stderr + chunk.toString("utf8")).slice(0, 2000);
+        });
+
+        child.on("error", (error) => {
+          finish({ error: formatSandboxExecutionError(verb, error) });
+        });
+
+        child.on("close", (exitCode, signal) => {
+          if (settled) return;
+
+          if (truncated) {
+            finish({
+              error:
+                `${verb} returned more than ${MAX_OUTPUT_BYTES / (1024 * 1024)}MB. ` +
+                "Return an aggregate — counts, groupings, a top-N list — not the features themselves.",
+            });
+            return;
+          }
+
+          if (!stdout) {
+            // No stdout means the runtime died before it could reply: almost
+            // always the heap cap, occasionally a crash. `stderr` carries V8's
+            // own message, which is more specific than anything guessable here.
+            const detail = stderr.trim().split("\n")[0] ?? "";
+            finish({
+              error:
+                `${verb} code execution was terminated (exit ${exitCode}${signal ? `, ${signal}` : ""})` +
+                `${detail ? `: ${detail}` : ""}. Hint: this is usually the ${MAX_HEAP_MB}MB memory ` +
+                "limit — aggregate incrementally instead of building large intermediate arrays.",
+            });
+            return;
+          }
+
+          try {
+            const reply = JSON.parse(stdout) as
+              | { ok: true; value: Result }
+              | { ok: false; name: string; message: string };
+            if (reply.ok) {
+              finish({ value: reply.value });
+              return;
+            }
+            // Rebuild an Error so the shared hint matcher sees the shape it would
+            // on the main thread — `name` drives the SyntaxError branch.
+            const error = new Error(reply.message);
+            error.name = reply.name;
+            finish({ error: formatSandboxExecutionError(verb, error) });
+          } catch {
+            finish({
+              error: `${verb} produced output that could not be parsed: ${stdout.slice(0, 200)}`,
+            });
+          }
+        });
+
+        child.stdin.on("error", () => {
+          // The child can exit before stdin drains (a syntax error in the runner,
+          // or the heap cap). `close` reports it; swallow EPIPE here.
+        });
+        child.stdin.end(payload);
+      });
+    },
+  };
+}
+
+/** The executor used by the analysis tool. */
+export const processSandboxExecutor: SandboxExecutor = createProcessSandboxExecutor();

--- a/src/tools/shared/sandbox/sandbox-code.ts
+++ b/src/tools/shared/sandbox/sandbox-code.ts
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ---------------------------------------------------------------------------
+ * VENDORED from the agent toolkit's
+ * `plugins/agent-toolkit/src/tools/shared/sandbox-code.ts`.
+ *
+ * The proposal (§2.7) recommended consuming this via a `"./sandbox"` subpath
+ * export on `@tomtom-org/maps-sdk-plugin-agent-toolkit` instead of copying it.
+ * That is still the right end state, and it is NOT done here for two reasons:
+ * adding a public subpath export is a change to a different repository's API
+ * surface, and the toolkit is not currently a dependency of this one (its `.`
+ * entrypoint reaches `create-map-agent` → `ai` → `maplibre-gl`, none of which
+ * belong in an MCP server).
+ *
+ * So: vendored, with the seams kept identical so the swap is a delete-and-import
+ * when that export lands. Everything below keeps the toolkit's exported names
+ * and contracts. What was dropped: the iframe-worker executor (browser-only) and
+ * `routeUtils` (a maps-sdk/map import). What was added: nothing — the Node
+ * worker executor lives in `worker-executor.ts` beside this file.
+ *
+ * If you change behaviour here, note it in this header so the divergence from
+ * upstream is visible.
+ * ---------------------------------------------------------------------------
+ */
+
+/** Chart.js chart types accepted when `outputFormat: "chart"`. */
+export const CHART_TYPES = new Set([
+  "bar",
+  "line",
+  "pie",
+  "doughnut",
+  "radar",
+  "polarArea",
+  "scatter",
+  "bubble",
+]);
+
+export type AnalysisOutputFormat = "json" | "chart";
+
+/** Lightweight structural check that a sandbox return value is a Chart.js config. */
+export const isChartConfiguration = (value: unknown): boolean => {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { type?: unknown; data?: unknown };
+  return (
+    typeof v.type === "string" &&
+    CHART_TYPES.has(v.type) &&
+    typeof v.data === "object" &&
+    v.data !== null
+  );
+};
+
+/**
+ * Globals shadowed to `undefined` inside every sandbox body.
+ *
+ * LLM-authored code has no legitimate need for network / storage / global
+ * reaches: its data is injected and its libraries are injected. Binding these as
+ * `undefined` parameters turns a stray `fetch(...)` into a loud
+ * "fetch is not a function" instead of a silent exfiltration.
+ *
+ * This is a TRIPWIRE, not a security boundary — the same capabilities stay
+ * reachable through constructor walks (`({}).constructor.constructor`). On a
+ * multi-tenant server the actual boundary is the worker thread
+ * (`worker-executor.ts`); this layer only surfaces accidents.
+ *
+ * `process` matters most: it is a direct global in Node and the first hop toward
+ * `child_process`.
+ */
+const SHADOWED_GLOBALS = [
+  "fetch",
+  "XMLHttpRequest",
+  "WebSocket",
+  "EventSource",
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+  "document",
+  "window",
+  "globalThis",
+  "self",
+  "navigator",
+  "importScripts",
+  "process",
+  "require",
+  "module",
+  "__dirname",
+  "__filename",
+] as const;
+
+/** Exported so any executor can apply the same shadowing inside its own realm. */
+export const sandboxedGlobalShadows = SHADOWED_GLOBALS;
+
+/**
+ * Pluggable strategy for executing sandbox code.
+ *
+ * `run` MUST resolve to `{ value }` or `{ error }` and never reject — execution
+ * failures are reported as `{ error }` via {@link formatSandboxExecutionError}.
+ */
+export type SandboxExecutor = {
+  run<Result = unknown>(
+    code: string,
+    paramNames: readonly string[],
+    args: readonly unknown[],
+    verb: string
+  ): Promise<{ value: Result } | { error: string }>;
+  /** Release held resources. No-op for the main-thread executor. */
+  destroy?(): void;
+};
+
+/**
+ * Compiles `code` as an async-function body taking `paramNames`, runs it with
+ * `args`, and returns `{ value }` or `{ error }`.
+ *
+ * Sanitising happens HERE, once, before dispatch, so every executor runs
+ * identically de-fanged code.
+ */
+export const runSandboxedFn = <Result = unknown>(
+  code: string,
+  paramNames: readonly string[],
+  args: readonly unknown[],
+  verb: string,
+  executor: SandboxExecutor
+): Promise<{ value: Result } | { error: string }> =>
+  executor.run<Result>(stripInjectedRedeclarations(code, paramNames), paramNames, args, verb);
+
+/**
+ * Strips redeclarations of injected identifiers.
+ *
+ * LLMs regularly prepend `const turf = require('@turf/turf')` out of habit,
+ * which is a parse-time "Identifier 'turf' has already been declared" before the
+ * body even runs. Only `require(...)` / `import(...)` / `arguments.x` right-hand
+ * sides are stripped: a name-only filter would also nuke a legitimate user
+ * variable that happens to share a name, corrupting the body and producing a far
+ * less actionable error.
+ */
+export const stripInjectedRedeclarations = (
+  code: string,
+  identifiers: readonly string[]
+): string => {
+  const names = identifiers.join("|");
+  const rhs =
+    String.raw`(?:(?:await\s+)?(?:require|import)\s*\(` +
+    String.raw`|arguments\s*(?:\[\s*\d+\s*\])?\s*(?:\.\w+|\[\s*['"]\w+['"]\s*\]))`;
+  const pattern = new RegExp(
+    String.raw`^[ \t]*(?:const|let|var)[ \t]+(?:${names})[ \t]*=[ \t]*${rhs}[^\n]*\n?`,
+    "gm"
+  );
+  return code.replace(pattern, "");
+};
+
+/**
+ * Normalises a sandbox return value to something JSON-safe.
+ *
+ * A JSON round-trip, NOT `structuredClone`: this must COERCE (drop `undefined`,
+ * `NaN`/`Infinity` → `null`, Date → ISO string, throw on circular). A faithful
+ * clone would preserve non-JSON values that then poison the tool response.
+ */
+const toJsonSafe = (value: unknown): { value: unknown } | { error: string } => {
+  try {
+    return { value: JSON.parse(JSON.stringify(value)) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      error:
+        `Returned value is not JSON-serializable: ${message}. ` +
+        "Return only plain objects, arrays, strings, numbers, booleans, and null — " +
+        "no functions, classes, circular references, or Map/Set instances.",
+    };
+  }
+};
+
+/** Validates the value returned by sandboxed analysis code. */
+export const validateAnalysisResult = (
+  analysis: unknown,
+  outputFormat: AnalysisOutputFormat
+): { value: unknown } | { error: string } => {
+  if (analysis === undefined) {
+    return {
+      error:
+        "Analysis code must return a value (the aggregation result). " +
+        "Hint: `code` is the function BODY, not a function expression. If you wrote " +
+        "`(args) => { ...; return result; }` as the whole code, the arrow is created and " +
+        "discarded — drop the wrapper and have the body itself end with `return result;`.",
+    };
+  }
+
+  const normalized = toJsonSafe(analysis);
+  if ("error" in normalized) return { error: normalized.error };
+
+  if (outputFormat === "chart" && !isChartConfiguration(normalized.value)) {
+    return {
+      error:
+        'Analysis code with `outputFormat: "chart"` must return a Chart.js ChartConfiguration ' +
+        '({ type: "bar"|"line"|"pie"|"doughnut"|"radar"|"polarArea"|"scatter"|"bubble", ' +
+        "data: { labels, datasets }, options? }).",
+    };
+  }
+
+  return { value: normalized.value };
+};
+
+/**
+ * Hints appended to LLM-facing error strings when the runtime message matches a
+ * known pitfall, so the model can self-correct instead of guessing.
+ *
+ * Order matters — library-specific rules come before the generic
+ * `is not a function` so callers get the targeted redirect.
+ */
+const SANDBOX_ERROR_HINTS: ReadonlyArray<{ pattern: RegExp; hint: string }> = [
+  {
+    pattern: /Cannot read propert(?:y|ies) of undefined/i,
+    hint: "A property was read on `undefined`. Likely a `reduce` callback that does not `return` the accumulator, or a `reduce` without an initial value — use `arr.reduce((acc, x) => { ...; return acc; }, {})`. Also check unguarded chains like `feature.properties.poi.categories` — use `?.` and `??`. Call tomtom-describe-dataset to see which paths actually exist.",
+  },
+  {
+    pattern: /Cannot read propert(?:y|ies) of null/i,
+    hint: "A property was read on `null`. Guard with `?.` and default with `??`.",
+  },
+  {
+    pattern: /\bh3\.\w+ is not a function/i,
+    hint: "`h3` is h3-js — hex-grid math only. NO spatial search, place lookup, or HTTP. Common: `latLngToCell`, `cellToLatLng`, `cellToBoundary`, `polygonToCells`, `gridDisk`, `cellArea`.",
+  },
+  {
+    pattern: /\bturf\.\w+ is not a function/i,
+    hint: "`turf` is @turf/turf v7 — GeoJSON geometry only. NO spatial search or HTTP. Common: `area`, `length`, `bbox`, `centroid`, `union`, `intersect`, `buffer`, `distance`, `booleanPointInPolygon`, `pointsWithinPolygon`, `clustersDbscan`. Verify names at https://turfjs.org/docs/.",
+  },
+  {
+    pattern: /coordinates must be an Array|Unknown Geometry Type/i,
+    hint: "turf was handed a raw coordinate (or a bare Array of features) instead of a Feature / FeatureCollection. Do NOT extract `.geometry.coordinates` and feed that to turf — pass the WHOLE feature. To span a collection, wrap: `turf.bbox(turf.featureCollection(features))`.",
+  },
+  {
+    pattern: /coord must be (?:a )?(?:GeoJSON )?Point|must be a Point/i,
+    hint: 'A point-only turf op was handed a non-Point feature. Datasets mix Point / LineString / Polygon geometries. Use `turf.booleanIntersects(feature, polygon)` for any geometry type, or guard with `if (f.geometry.type === "Point")`, or reduce to a point first with `turf.pointOnFeature(f)`.',
+  },
+  {
+    pattern: /is not a function/i,
+    hint: "A method was called on a value that does not have it (typo, or the value is not the expected type). Verify first, e.g. `Array.isArray(x) ? x.map(...) : []`.",
+  },
+  {
+    pattern: /Illegal return statement/i,
+    hint: "A `return` sits outside the top-level function body — usually a missing brace, or a multi-line callback whose closing `})` was lost. Re-emit with balanced braces and `return` only at the top level.",
+  },
+  {
+    pattern: /Identifier ['"]?\w+['"]? has already been declared/i,
+    hint: "A variable was declared twice — typically `const turf = require(...)` or `const datasets = ...`. Those names are already function parameters; drop the redeclaration and use them directly.",
+  },
+  {
+    pattern: /Unexpected (?:token|identifier|end of input)/i,
+    hint: "The code did not parse as an async-function body. Common causes: unbalanced braces/parens, a stray template literal, or `import`/`export` statements (not allowed — `datasets`, `turf` and `h3` are already in scope). Re-emit a self-contained body ending in `return ...;`.",
+  },
+  {
+    pattern: /\brequire is not defined\b|\bimport (?:is not defined|outside a module)\b/i,
+    hint: "The sandbox is not a module — `require` and top-level `import` are unavailable. The libraries (`turf`, `h3`) and your data are already injected as parameters.",
+  },
+  {
+    pattern: /\b(?:fetch|XMLHttpRequest|process|globalThis) is not (?:a function|defined)\b/i,
+    hint: "Network, filesystem and process access are blocked by design. The sandbox works only on the datasets passed in. To bring in more data, call the search/routing tool first and pass its dataset_id.",
+  },
+  {
+    pattern: /\b(?:functions|tools|agent)\b.*is not defined/i,
+    hint: "The sandbox cannot call other tools. List every dataset you need in `dataset_ids` — each arrives in `datasets`, keyed by id.",
+  },
+  {
+    pattern: /is not iterable/i,
+    hint: "A value used in `for..of`, spread, or destructuring was not iterable. Default arrays with `?? []`.",
+  },
+  {
+    pattern: /Cannot access '.+?' before initialization/i,
+    hint: "A `let`/`const` was used before its declaration. Move the declaration above its first use.",
+  },
+  {
+    pattern: /Assignment to constant variable/i,
+    hint: "A `const` was reassigned. Use `let`, or mutate in place.",
+  },
+  {
+    pattern: /could not be cloned|DataCloneError/i,
+    hint: "The return value must be pure JSON — no functions, classes, Maps or Sets. It crosses a worker boundary before reaching you.",
+  },
+];
+
+/**
+ * Builds an LLM-facing error string for a sandbox failure, appending a `Hint:`
+ * when the message matches a known pattern.
+ */
+export const formatSandboxExecutionError = (verb: string, error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  const base = `${verb} code execution failed: ${message}`;
+  const match = SANDBOX_ERROR_HINTS.find(({ pattern }) => pattern.test(message));
+  if (match) return `${base} Hint: ${match.hint}`;
+  if (error instanceof Error && error.name === "SyntaxError") {
+    return `${base} Hint: the provided \`code\` is not valid JavaScript — ensure it parses as an async function body and \`return\`s a value.`;
+  }
+  return base;
+};

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -108,8 +108,9 @@ export const TOOL_REGISTRY = [
       'One call covers what used to take three — "italian restaurants in Amsterdam" is ' +
       '`poiCategories: ["italian food"]` plus `where: { mode: "within", queries: ["Amsterdam"] }`. ' +
       "EV searches with an ELECTRIC_VEHICLE_STATION category near a point include live charger " +
-      "availability. Results are capped and trimmed to fit the conversation, so narrow the " +
-      "query rather than counting or aggregating over what you were shown. " +
+      "availability. Results are capped and trimmed to fit the conversation, so never count or " +
+      "aggregate over what you were shown — pass `analyse` to run code over the FULL result set " +
+      "on the server and get back just the number. " +
       "To locate ONE specific named place, or to get an area's boundary polygon, use " +
       "tomtom-locate-place instead.",
     inputSchema: tomtomDiscoverPlacesSchema,
@@ -283,8 +284,8 @@ export const TOOL_REGISTRY = [
       "caps an area at 10,000 km², which the span of a long route exceeds. " +
       "Dense areas return far more incidents than are shown. The visible ones are the MOST SEVERE, " +
       "ranked by delay magnitude, so the worst incident is the first of them. A count, total or " +
-      "per-road breakdown computed from the visible list is WRONG whenever the area was capped; " +
-      "narrow the area instead. " +
+      "per-road breakdown computed from the visible list is WRONG whenever the area was capped: " +
+      "pass `analyse` instead and the code runs over every incident found. " +
       "Incidents are drawn on an interactive map; do not plot them with tomtom-dynamic-map.",
     inputSchema: tomtomGetTrafficSchema,
     handler: getTrafficHandler,

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { redactCredentials } from "./redact";
+
+describe("redactCredentials", () => {
+  it("removes the key the SDK echoes into reachable-range feature properties", () => {
+    // The real shape, measured: every isochrone feature carried the live key.
+    const response = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Polygon", coordinates: [] },
+          properties: {
+            apiKey: "0123456789abcdef0123456789abcdef",
+            commonBaseURL: "https://api.tomtom.com",
+            budget: { type: "time", value: 600 },
+          },
+        },
+      ],
+    };
+
+    redactCredentials(response);
+
+    expect(response.features[0].properties).not.toHaveProperty("apiKey");
+    // Non-credential config is left alone — it is noise, not a secret.
+    expect(response.features[0].properties.budget).toEqual({ type: "time", value: 600 });
+  });
+
+  it("matches regardless of case and nesting", () => {
+    const value = { a: { b: [{ ApiKey: "x", Authorization: "y", keep: 1 }] } };
+    redactCredentials(value);
+    expect(value.a.b[0]).toEqual({ keep: 1 });
+  });
+
+  it("leaves legitimate map data that merely resembles a credential name", () => {
+    // A redactor that eats real results is worse than the leak it prevents.
+    const value = { properties: { poi: { name: "Turnkey Bakery" }, keyword: "bread" } };
+    redactCredentials(value);
+    expect(value.properties.poi.name).toBe("Turnkey Bakery");
+    expect(value.properties.keyword).toBe("bread");
+  });
+
+  it("survives values it cannot walk", () => {
+    expect(redactCredentials(null)).toBeNull();
+    expect(redactCredentials("plain")).toBe("plain");
+  });
+});

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 TomTom Navigation B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Strips credentials out of an upstream response before anything else sees it.
+ *
+ * Not hypothetical tidying. The maps SDK echoes the request parameters it was
+ * given into the properties of every feature it returns, so a reachable-range
+ * result carries `properties.apiKey` holding the real TomTom key — measured, not
+ * assumed. The field trimmers happened to drop it on the way to the model, which
+ * is why it went unnoticed; nothing dropped it on the way to the dataset store,
+ * or to `analyse` code the model wrote.
+ *
+ * A sandbox handed a credential is a credential-exfiltration path whatever else
+ * it denies: Node's permission model does not cover sockets, so a body that can
+ * read the key can post it somewhere. Redacting at the boundary removes the
+ * exposure instead of relying on every downstream consumer to avoid it.
+ */
+
+/**
+ * Property names that never belong in a response body.
+ *
+ * Compared case-insensitively, and deliberately narrow: a rule like "anything
+ * containing `key`" would eat legitimate map data, and a redactor that corrupts
+ * results is worse than the leak it prevents.
+ */
+const CREDENTIAL_KEYS = new Set([
+  "apikey",
+  "api_key",
+  "x-api-key",
+  "subscriptionkey",
+  "authorization",
+  "token",
+  "bearer",
+]);
+
+/** How deep to walk. Responses are wide, not deep; this bounds pathological input. */
+const MAX_DEPTH = 12;
+
+/**
+ * Returns `value` with every credential-named property removed.
+ *
+ * Mutates in place and returns the same reference: the caller owns a freshly
+ * parsed upstream response, and copying a several-thousand-feature collection to
+ * delete two fields is a cost with no benefit.
+ */
+export function redactCredentials<T>(value: T, depth = 0): T {
+  if (depth > MAX_DEPTH || value === null || typeof value !== "object") return value;
+
+  if (Array.isArray(value)) {
+    for (const item of value) redactCredentials(item, depth + 1);
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const name of Object.keys(record)) {
+    if (CREDENTIAL_KEYS.has(name.toLowerCase())) {
+      delete record[name];
+      continue;
+    }
+    redactCredentials(record[name], depth + 1);
+  }
+  return value;
+}


### PR DESCRIPTION
**Stage 2 of a three-stage plan to make the Maps MCP server answer questions it currently cannot.** It answers **problem 2: the agent only ever sees a trimmed projection of the result.**

📄 **Confluence:** [Maps MCP Improvements](https://tomtom.atlassian.net/wiki/spaces/LSI/pages/2414445120/Maps+MCP+Improvements) · [Introduction — the problem and the plan](https://tomtom.atlassian.net/wiki/spaces/LSI/pages/2413953628/Introduction+the+problem+and+the+plan) · **[Stage 2 — Compute on the server](https://tomtom.atlassian.net/wiki/spaces/LSI/pages/2414117478/Stage+2+Compute+on+the+server)** (this PR)

| | Stage | Adds | PR |
| --- | --- | --- | --- |
| 0 | today's server | — | — |
| 1 | reshape the tools | task-shaped tools; no sandbox, no state | #266 |
| **2** | **compute on the server** | **`analyse` — code over a call's own result** | **this PR** |
| 3 | hold and describe results | `dataset_id` handles, `describe-dataset`, `analyse-data` | #262 |

> **Base branch:** targets #266, so the diff shows only this stage.

## The problem this stage solves

A response is a capped, trimmed projection: the traffic tool shows the most severe hundred of several thousand incidents, and the search trimmer deletes `openingHours` and category data outright. A total computed from a capped list is not an approximation — it is the wrong number.

## How it works

Every data tool takes an optional **`analyse`**: a JavaScript function body run on the server against the **full untrimmed result of that same call**, returning only what the code returns.

```jsonc
tomtom-get-traffic({
  where: { mode: "within", queries: ["Amsterdam"] },
  analyse: "return features.length"
})
→ { "analysis": 189, "queriedOver": { "tool": "Traffic", "features": 189 } }
```

189 incidents counted; none crossed the conversation. `features`, `data`, `turf` and `h3` are in scope.

**A field, not a `tomtom-analyse-data` tool.** With nothing held between calls there is no handle for an analysis tool to receive. Keeping it a field also leaves the tool *list* byte-identical to stage 1's, so the stage 1 → 2 delta measures code execution and not a new routing target.

## Each tool documents its own result shape

`analyse` runs in the **same call** that produces the data, so the model writes its filter having never seen a response. Each tool therefore carries its result shape in its schema (`src/schemas/shared/response-shapes.ts`) — the fields a question is likely to need, and the traps that produce silently empty answers:

- connector details sit under a nested `connectors[].connector`, not `connectors[]`
- traffic arrives under `incidents`, not `features`
- `roadNumbers` is absent on incidents not on a numbered road
- routes carry no turn-by-turn guidance at all

Every path was read off a live response rather than from the SDK's types.

That placement is **forced by statelessness rather than chosen**: with nothing held between calls there is no analysis tool to hang the shapes on, so they ship on all five tools in every `tools/list` — about 670 tokens, paid whether or not any code runs. A stateful surface keys the same facts by dataset kind on one tool (~560 tokens); the gap is small at this tool count and grows with it.

## Measured

Azure `gpt-5.1`, stdio, medians of 3 runs, all four servers interleaved in one session.

| median | today | stage 1 | **stage 2** |
| --- | ---: | ---: | ---: |
| questions answered | 8 (6–8) | 9 (8–9) | **9 (8–10)** |
| grounded | 9 | 11 | **11** |
| previously impossible, answered | 3 | 4 | **4** |
| tokens | 858,797 | 428,239 | **339,940** |
| routing accuracy | 85.7% | 100% | **100%** |

**The cheapest surface of the four — 60% below today's token cost**, answering the same 9 as stage 1 for 20% fewer tokens. Its code execution pays for itself on the route's northernmost point (2/3 → 3/3) and the EV connector histogram (0/3 → 2/3); stage 1's better tools had already picked up the incident totals.

## What this stage cannot do

The code sees **one tool's result**. *"Which of these chargers is inside that isochrone"* spans two calls. The gap to stage 3 is two questions and they are exactly those: `cross-incidents-near-route` (0/3 vs 2/3) and `cross-ev-within-range` (1/3 vs 2/3) — relating one result to another. That is what handles buy.

## ⚠️ Security

The sandbox runs model-authored code in a jailed child process: empty temp `cwd`, `--permission` read grant limited to `node_modules`, `env: {}`, heap cap, `SIGKILL` on timeout. Filesystem, environment and subprocess access are denied and asserted in tests. Credentials are redacted from every result before code can read them (see #266).

**Open:** Node's permission model does not cover sockets, so **network egress is not denied**. A body could post the data it was handed. This needs a container egress policy before a hosted endpoint — the same condition stage 3 carries, not an additional one.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `pnpm type-check` / `pnpm check` — clean
- [x] `pnpm test` — **455 passing**
- [x] `pnpm build` — clean, 9 apps
- [x] End to end over the real MCP wire: `tomtom-get-traffic` with an `analyse` body aggregated 189 live incidents by road number and returned the top 5
- [x] Credential redaction verified against the running server
- [x] Scored on the same corpus as every other stage — numbers above

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed-off my commits as per the DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)
